### PR TITLE
feat: support record only mode

### DIFF
--- a/driving_log_replayer_v2/launch/driving_log_replayer_v2.launch.py
+++ b/driving_log_replayer_v2/launch/driving_log_replayer_v2.launch.py
@@ -122,6 +122,13 @@ def create_output_dir(output_dir_str: str, scenario_path: Path) -> Path:
     return output_dir
 
 
+def output_dummy_result_jsonl(result_json_path: str) -> None:
+    jsonl_path_str = result_json_path + "l"
+    with Path(jsonl_path_str).open("w") as f:
+        dummy_str = '{"Result": {"Success": true, "Summary": "RecordOnlyMode"}, "Stamp": {"System": 0.0}, "Frame": {}}'
+        f.write(dummy_str + "\n")
+
+
 def check_launch_component(conf: dict) -> dict:
     use_case_launch_arg = driving_log_replayer_v2_config[conf["use_case"]]["disable"]
     # update autoware component launch or not
@@ -276,6 +283,8 @@ def launch_map_height_fitter(context: LaunchContext) -> list:
 def launch_evaluator_node(context: LaunchContext) -> list:
     conf = context.launch_configurations
     if conf["record_only"] != "false":
+        # output dummy result for Evaluator
+        output_dummy_result_jsonl(conf["result_json_path"])
         return [LogInfo(msg="evaluator_node is not launched because record_only is set")]
     params = {
         "use_sim_time": True,

--- a/driving_log_replayer_v2/launch/driving_log_replayer_v2.launch.py
+++ b/driving_log_replayer_v2/launch/driving_log_replayer_v2.launch.py
@@ -101,7 +101,7 @@ def get_launch_arguments() -> list:
     add_launch_arg(
         "override_topics_regex",
         default_value="",
-        description="use allowlist. Ex: override_topics_regex:=\^/tf\$\|/sensing/lidar/concatenated/pointcloud\|\^/perception/.*/objects\$",  # noqa
+        description="use allowlist. Ex: override_topics_regex:=\^/tf\$\|/sensing/lidar/concatenated/pointcloud\|\^/perception/.\*/objects\$",  # noqa
     )
 
     return launch_arguments

--- a/driving_log_replayer_v2/launch/driving_log_replayer_v2.launch.py
+++ b/driving_log_replayer_v2/launch/driving_log_replayer_v2.launch.py
@@ -353,7 +353,11 @@ def launch_bag_player(
         )
     if len(remap_list) != 1:
         play_cmd.extend(remap_list)
-    bag_player = ExecuteProcess(cmd=play_cmd, output="screen")
+    bag_player = (
+        ExecuteProcess(cmd=play_cmd, output="screen", on_exit=[ShutdownOnce()])
+        if conf["record_only"] == "true"
+        else ExecuteProcess(cmd=play_cmd, output="screen")
+    )
     return [bag_player]
 
 

--- a/driving_log_replayer_v2/launch/driving_log_replayer_v2.launch.py
+++ b/driving_log_replayer_v2/launch/driving_log_replayer_v2.launch.py
@@ -46,6 +46,8 @@ def get_launch_arguments() -> list:
     play_rate
     play_delay
     with_autoware
+    record_only
+    override_topics_regex
     """
     launch_arguments = []
 
@@ -90,6 +92,16 @@ def get_launch_arguments() -> list:
         "with_autoware",
         default_value="true",
         description="Whether to launch Autoware or not. set false if Autoware is started on a different PC.",
+    )
+    add_launch_arg(
+        "record_only",
+        default_value="false",
+        description="Do only bag record without starting evaluator node",
+    )
+    add_launch_arg(
+        "override_topics_regex",
+        default_value="",
+        description="use allowlist. Ex: override_topics_regex:=\^/clock\$\|\^/tf\$\|/sensing/lidar/concatenated/pointcloud",  # noqa
     )
 
     return launch_arguments
@@ -263,6 +275,8 @@ def launch_map_height_fitter(context: LaunchContext) -> list:
 
 def launch_evaluator_node(context: LaunchContext) -> list:
     conf = context.launch_configurations
+    if conf["record_only"] != "false":
+        return [LogInfo(msg="evaluator_node is not launched because record_only is set")]
     params = {
         "use_sim_time": True,
         "scenario_path": conf["scenario_path"],
@@ -357,10 +371,13 @@ def launch_bag_recorder(context: LaunchContext) -> list:
             "config",
             "qos.yaml",
         ).as_posix(),
-        "-e",
-        driving_log_replayer_v2_config[conf["use_case"]]["record"],
         "--use-sim-time",
+        "-e",
     ]
+    if conf["override_topics_regex"] == "":
+        record_cmd.append(driving_log_replayer_v2_config[conf["use_case"]]["record"])
+    else:
+        record_cmd.append(conf["override_topics_regex"])
     return [ExecuteProcess(cmd=record_cmd)]
 
 

--- a/driving_log_replayer_v2/launch/driving_log_replayer_v2.launch.py
+++ b/driving_log_replayer_v2/launch/driving_log_replayer_v2.launch.py
@@ -363,7 +363,11 @@ def launch_bag_player(
     if len(remap_list) != 1:
         play_cmd.extend(remap_list)
     bag_player = (
-        ExecuteProcess(cmd=play_cmd, output="screen", on_exit=[ShutdownOnce()])
+        ExecuteProcess(
+            cmd=play_cmd,
+            output="screen",
+            on_exit=[ExecuteProcess(cmd=["sleep", "3"], on_exit=[ShutdownOnce()])],
+        )  # 圧縮入れると書き込みに時間かかってplayが終わって即終了だとrecordの終了間に合わない
         if conf["record_only"] == "true"
         else ExecuteProcess(cmd=play_cmd, output="screen")
     )
@@ -376,6 +380,8 @@ def launch_bag_recorder(context: LaunchContext) -> list:
         "ros2",
         "bag",
         "record",
+        "-s",
+        "mcap",
         "-o",
         conf["result_bag_path"],
         "--qos-profile-overrides-path",
@@ -384,6 +390,8 @@ def launch_bag_recorder(context: LaunchContext) -> list:
             "config",
             "qos.yaml",
         ).as_posix(),
+        "--storage-preset-profile",
+        "zstd_fast",
         "--use-sim-time",
         "-e",
     ]

--- a/driving_log_replayer_v2/launch/driving_log_replayer_v2.launch.py
+++ b/driving_log_replayer_v2/launch/driving_log_replayer_v2.launch.py
@@ -106,7 +106,7 @@ def get_launch_arguments() -> list:
     )
     add_launch_arg(
         "storage",
-        default_value="mcap",
+        default_value="sqlite3",  # Settings are adjusted to ros distro standards. Currently autoware is humble, so use sqlite3. Change to mcap when updated to jazzy.
         description="select storage type mcap or sqlite3",
     )
 

--- a/driving_log_replayer_v2/launch/driving_log_replayer_v2.launch.py
+++ b/driving_log_replayer_v2/launch/driving_log_replayer_v2.launch.py
@@ -101,7 +101,7 @@ def get_launch_arguments() -> list:
     add_launch_arg(
         "override_topics_regex",
         default_value="",
-        description="use allowlist. Ex: override_topics_regex:=\^/clock\$\|\^/tf\$\|/sensing/lidar/concatenated/pointcloud",  # noqa
+        description="use allowlist. Ex: override_topics_regex:=\^/tf\$\|/sensing/lidar/concatenated/pointcloud\|\^/perception/.*/objects\$",  # noqa
     )
 
     return launch_arguments


### PR DESCRIPTION
## Types of PR

- [x] New Features

## Description

- record multi perception objects
- add `record_only` `override_topics_regex` argument

```shell
ros2 launch driving_log_replayer_v2 driving_log_replayer_v2.launch.py scenario_path:=$HOME/dlr2_data/x2_multi/scenario.yaml record_only:=true override_topics_regex:=\^/tf\$\|/sensing/lidar/concatenated/pointcloud\|\^/perception/.\*/objects\$
```

## How to review this PR

## Others
