### PR TITLE
feat(perception): add prediction evaluation

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/perception_eval_conversions.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/perception_eval_conversions.py
@@ -15,27 +15,25 @@
 import json
 from pathlib import Path
 
-from ament_index_python.packages import get_package_share_directory
-from builtin_interfaces.msg import Time
 import fastjsonschema
+import numpy as np
+from ament_index_python.packages import get_package_share_directory
+from autoware_perception_msgs.msg import PredictedPath
+from builtin_interfaces.msg import Time
 from geometry_msgs.msg import Point
 from geometry_msgs.msg import Polygon as RosPolygon
 from geometry_msgs.msg import Pose
 from geometry_msgs.msg import Quaternion as RosQuaternion
 from geometry_msgs.msg import Vector3
-import numpy as np
 from perception_eval.common import ObjectType
-from perception_eval.common.object import DynamicObject
-from perception_eval.common.object import ObjectState
+from perception_eval.common.object import DynamicObject, ObjectState
 from perception_eval.evaluation.result.object_result import DynamicObjectWithPerceptionResult
 from perception_eval.evaluation.result.perception_pass_fail_result import PassFailResult
 from pyquaternion.quaternion import Quaternion
 from rclpy.time import Duration
 from shapely.geometry import Polygon
-from std_msgs.msg import ColorRGBA
-from std_msgs.msg import Header
-from visualization_msgs.msg import Marker
-from visualization_msgs.msg import MarkerArray
+from std_msgs.msg import ColorRGBA, Header
+from visualization_msgs.msg import Marker, MarkerArray
 
 
 def unix_time_from_ros_msg(ros_header: Header) -> int:
@@ -52,6 +50,14 @@ def position_from_ros_msg(ros_position: Point) -> tuple[int, int, int]:
 
 def orientation_from_ros_msg(ros_orientation: RosQuaternion) -> Quaternion:
     return Quaternion(ros_orientation.w, ros_orientation.x, ros_orientation.y, ros_orientation.z)
+
+
+def path_positions_from_ros_msg(ros_path: PredictedPath) -> list[tuple[float, float, float]]:
+    return [position_from_ros_msg(pose.position) for pose in ros_path.path]
+
+
+def path_orientations_from_ros_msg(ros_path: PredictedPath) -> list[Quaternion]:
+    return [orientation_from_ros_msg(pose.orientation) for pose in ros_path.path]
 
 
 def dimensions_from_ros_msg(

--- a/driving_log_replayer_v2/driving_log_replayer_v2/perception_eval_conversions.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/perception_eval_conversions.py
@@ -15,25 +15,28 @@
 import json
 from pathlib import Path
 
-import fastjsonschema
-import numpy as np
 from ament_index_python.packages import get_package_share_directory
 from autoware_perception_msgs.msg import PredictedPath
 from builtin_interfaces.msg import Time
+import fastjsonschema
 from geometry_msgs.msg import Point
 from geometry_msgs.msg import Polygon as RosPolygon
 from geometry_msgs.msg import Pose
 from geometry_msgs.msg import Quaternion as RosQuaternion
 from geometry_msgs.msg import Vector3
+import numpy as np
 from perception_eval.common import ObjectType
-from perception_eval.common.object import DynamicObject, ObjectState
+from perception_eval.common.object import DynamicObject
+from perception_eval.common.object import ObjectState
 from perception_eval.evaluation.result.object_result import DynamicObjectWithPerceptionResult
 from perception_eval.evaluation.result.perception_pass_fail_result import PassFailResult
 from pyquaternion.quaternion import Quaternion
 from rclpy.time import Duration
 from shapely.geometry import Polygon
-from std_msgs.msg import ColorRGBA, Header
-from visualization_msgs.msg import Marker, MarkerArray
+from std_msgs.msg import ColorRGBA
+from std_msgs.msg import Header
+from visualization_msgs.msg import Marker
+from visualization_msgs.msg import MarkerArray
 
 
 def unix_time_from_ros_msg(ros_header: Header) -> int:

--- a/driving_log_replayer_v2/scripts/perception_evaluator_node.py
+++ b/driving_log_replayer_v2/scripts/perception_evaluator_node.py
@@ -14,37 +14,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 from collections.abc import Callable
+import logging
 from pathlib import Path
 
-import driving_log_replayer_v2.perception_eval_conversions as eval_conversions
-import rclpy
-from autoware_perception_msgs.msg import (
-    DetectedObject,
-    DetectedObjects,
-    PredictedObject,
-    PredictedObjects,
-)
+from autoware_perception_msgs.msg import DetectedObject
+from autoware_perception_msgs.msg import DetectedObjects
+from autoware_perception_msgs.msg import PredictedObject
+from autoware_perception_msgs.msg import PredictedObjects
 from autoware_perception_msgs.msg import Shape as MsgShape
-from autoware_perception_msgs.msg import TrackedObject, TrackedObjects
-from driving_log_replayer_v2.evaluator import DLREvaluatorV2, evaluator_main
-from driving_log_replayer_v2.perception import PerceptionResult, PerceptionScenario
+from autoware_perception_msgs.msg import TrackedObject
+from autoware_perception_msgs.msg import TrackedObjects
 from perception_eval.common.object import DynamicObject
 from perception_eval.common.schema import FrameID
-from perception_eval.common.shape import Shape, ShapeType
+from perception_eval.common.shape import Shape
+from perception_eval.common.shape import ShapeType
 from perception_eval.common.status import get_scene_rates
 from perception_eval.config import PerceptionEvaluationConfig
-from perception_eval.evaluation import PerceptionFrameResult, get_object_status
+from perception_eval.evaluation import get_object_status
+from perception_eval.evaluation import PerceptionFrameResult
 from perception_eval.evaluation.metrics import MetricsScore
-from perception_eval.evaluation.result.perception_frame_config import (
-    CriticalObjectFilterConfig,
-    PerceptionPassFailConfig,
-)
+from perception_eval.evaluation.result.perception_frame_config import CriticalObjectFilterConfig
+from perception_eval.evaluation.result.perception_frame_config import PerceptionPassFailConfig
 from perception_eval.manager import PerceptionEvaluationManager
 from perception_eval.tool import PerceptionAnalyzer3D
 from perception_eval.util.logger_config import configure_logger
+import rclpy
 from visualization_msgs.msg import MarkerArray
+
+from driving_log_replayer_v2.evaluator import DLREvaluatorV2
+from driving_log_replayer_v2.evaluator import evaluator_main
+from driving_log_replayer_v2.perception import PerceptionResult
+from driving_log_replayer_v2.perception import PerceptionScenario
+import driving_log_replayer_v2.perception_eval_conversions as eval_conversions
 
 
 class PerceptionEvaluator(DLREvaluatorV2):

--- a/driving_log_replayer_v2/scripts/perception_evaluator_node.py
+++ b/driving_log_replayer_v2/scripts/perception_evaluator_node.py
@@ -210,10 +210,14 @@ class PerceptionEvaluator(DLREvaluatorV2):
                 unix_time=unix_time,
                 frame_id=self.__frame_id,
                 position=eval_conversions.position_from_ros_msg(
-                    perception_object.kinematics.pose_with_covariance.pose.position,
+                    perception_object.kinematics.pose_with_covariance.pose.position
+                    if isinstance(perception_object, DetectedObject | TrackedObject)
+                    else perception_object.kinematics.initial_pose_with_covariance.pose.position
                 ),
                 orientation=eval_conversions.orientation_from_ros_msg(
-                    perception_object.kinematics.pose_with_covariance.pose.orientation,
+                    perception_object.kinematics.pose_with_covariance.pose.orientation
+                    if isinstance(perception_object, DetectedObject | TrackedObject)
+                    else perception_object.kinematics.initial_pose_with_covariance.pose.orientation
                 ),
                 shape=Shape(
                     shape_type=shape_type,
@@ -226,10 +230,16 @@ class PerceptionEvaluator(DLREvaluatorV2):
                     ),
                 ),
                 velocity=eval_conversions.velocity_from_ros_msg(
-                    perception_object.kinematics.twist_with_covariance.twist.linear,
+                    perception_object.kinematics.twist_with_covariance.twist.linear
+                    if isinstance(perception_object, DetectedObject | TrackedObject)
+                    else perception_object.kinematics.initial_twist_with_covariance.twist.linear
                 ),
-                pose_covariance=perception_object.kinematics.pose_with_covariance.covariance,
-                twist_covariance=perception_object.kinematics.twist_with_covariance.covariance,
+                pose_covariance=perception_object.kinematics.pose_with_covariance.covariance
+                if isinstance(perception_object, DetectedObject | TrackedObject)
+                else perception_object.kinematics.initial_pose_with_covariance.covariance,
+                twist_covariance=perception_object.kinematics.twist_with_covariance.covariance
+                if isinstance(perception_object, DetectedObject | TrackedObject)
+                else perception_object.kinematics.initial_twist_with_covariance.covariance,
                 semantic_score=most_probable_classification.probability,
                 semantic_label=label,
                 uuid=uuid,

--- a/driving_log_replayer_v2/scripts/perception_evaluator_node.py
+++ b/driving_log_replayer_v2/scripts/perception_evaluator_node.py
@@ -14,39 +14,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections.abc import Callable
 import logging
+from collections.abc import Callable
 from pathlib import Path
 
-from autoware_perception_msgs.msg import DetectedObject
-from autoware_perception_msgs.msg import DetectedObjects
-from autoware_perception_msgs.msg import PredictedObject
-from autoware_perception_msgs.msg import PredictedObjects
+import driving_log_replayer_v2.perception_eval_conversions as eval_conversions
+import rclpy
+from autoware_perception_msgs.msg import (
+    DetectedObject,
+    DetectedObjects,
+    PredictedObject,
+    PredictedObjects,
+)
 from autoware_perception_msgs.msg import Shape as MsgShape
-from autoware_perception_msgs.msg import TrackedObject
-from autoware_perception_msgs.msg import TrackedObjects
+from autoware_perception_msgs.msg import TrackedObject, TrackedObjects
+from driving_log_replayer_v2.evaluator import DLREvaluatorV2, evaluator_main
+from driving_log_replayer_v2.perception import PerceptionResult, PerceptionScenario
 from perception_eval.common.object import DynamicObject
 from perception_eval.common.schema import FrameID
-from perception_eval.common.shape import Shape
-from perception_eval.common.shape import ShapeType
+from perception_eval.common.shape import Shape, ShapeType
 from perception_eval.common.status import get_scene_rates
 from perception_eval.config import PerceptionEvaluationConfig
-from perception_eval.evaluation import get_object_status
-from perception_eval.evaluation import PerceptionFrameResult
+from perception_eval.evaluation import PerceptionFrameResult, get_object_status
 from perception_eval.evaluation.metrics import MetricsScore
-from perception_eval.evaluation.result.perception_frame_config import CriticalObjectFilterConfig
-from perception_eval.evaluation.result.perception_frame_config import PerceptionPassFailConfig
+from perception_eval.evaluation.result.perception_frame_config import (
+    CriticalObjectFilterConfig,
+    PerceptionPassFailConfig,
+)
 from perception_eval.manager import PerceptionEvaluationManager
 from perception_eval.tool import PerceptionAnalyzer3D
 from perception_eval.util.logger_config import configure_logger
-import rclpy
 from visualization_msgs.msg import MarkerArray
-
-from driving_log_replayer_v2.evaluator import DLREvaluatorV2
-from driving_log_replayer_v2.evaluator import evaluator_main
-from driving_log_replayer_v2.perception import PerceptionResult
-from driving_log_replayer_v2.perception import PerceptionScenario
-import driving_log_replayer_v2.perception_eval_conversions as eval_conversions
 
 
 class PerceptionEvaluator(DLREvaluatorV2):
@@ -243,6 +241,23 @@ class PerceptionEvaluator(DLREvaluatorV2):
                 semantic_score=most_probable_classification.probability,
                 semantic_label=label,
                 uuid=uuid,
+                predicted_positions=[
+                    eval_conversions.path_positions_from_ros_msg(path)
+                    for path in perception_object.kinematics.predicted_paths
+                ]
+                if isinstance(perception_object, PredictedObject)
+                else None,
+                predicted_orientations=[
+                    eval_conversions.path_orientations_from_ros_msg(path)
+                    for path in perception_object.kinematics.predicted_paths
+                ]
+                if isinstance(perception_object, PredictedObject)
+                else None,
+                predicted_scores=[
+                    path.confidence for path in perception_object.kinematics.predicted_paths
+                ]
+                if isinstance(perception_object, PredictedObject)
+                else None,
             )
             estimated_objects.append(estimated_object)
         return estimated_objects

--- a/sample/perception/scenario.yaml
+++ b/sample/perception/scenario.yaml
@@ -29,7 +29,7 @@ Evaluation:
             y_position: null # [m] null [Do not filter by y_position] or lower_limit,upper_limit
   PerceptionEvaluationConfig:
     evaluation_config_dict:
-      evaluation_task: detection # detection or tracking. Evaluate the objects specified here
+      evaluation_task: detection # detection, tracking, or prediction. Evaluate the objects specified here
       target_labels: [car, bicycle, pedestrian, motorbike] # evaluation label
       max_x_position: 102.4 # Maximum x position of object to be evaluated
       max_y_position: 102.4 # Maximum y position of object to be evaluated


### PR DESCRIPTION
## Types of PR

- [x] New Features

## Description

- add prediction evaluation
- https://github.com/tier4/autoware_perception_evaluation/pull/11

## How to review this PR

use sample dataset for perception
https://tier4.github.io/driving_log_replayer_v2/quick_start/setup/

update evaluation `prediction` like below sceanario
[prediction.yaml.txt](https://github.com/user-attachments/files/17726743/prediction.yaml.txt)


```shell
ros2 launch driving_log_replayer_v2 driving_log_replayer_v2.launch.py scenario_path:=$HOME/dlr2_data/perception/prediction.yaml
```

## Others
