### PR TITLE
feat: bag play remap

### DIFF
--- a/driving_log_replayer_v2/launch/driving_log_replayer_v2.launch.py
+++ b/driving_log_replayer_v2/launch/driving_log_replayer_v2.launch.py
@@ -347,41 +347,41 @@ def launch_bag_player(
             "qos.yaml",
         ).as_posix(),
     ]
-    remap_set = {"--remap"}
+    remap_list = ["--remap"]
     if conf.get("sensing", "true") == "true":
-        remap_set.add(
+        remap_list.append(
             "/sensing/lidar/concatenated/pointcloud:=/unused/concatenated/pointcloud",
         )
     if conf.get("localization", "true") == "true":
-        remap_set.add(
+        remap_list.append(
             "/tf:=/unused/tf",
         )
-        remap_set.add(
+        remap_list.append(
             "/localization/kinematic_state:=/unused/localization/kinematic_state",
         )
-        remap_set.add(
+        remap_list.append(
             "/localization/acceleration:=/unused/localization/acceleration",
         )
     if conf.get("perception", "true") == "true":
         # remap perception msgs in bag
-        remap_set.add(
+        remap_list.append(
             "/perception/obstacle_segmentation/pointcloud:=/unused/perception/obstacle_segmentation/pointcloud",
         )
-        remap_set.add(
+        remap_list.append(
             "/perception/object_recognition/objects:=/unused/perception/object_recognition/objects",
         )
     if conf.get("goal_pose") is not None:
-        remap_set.add(
+        remap_list.append(
             "/planning/mission_planning/route:=/unused/planning/mission_planning/route",
         )
     # user defined remap
     if conf["remap"] != "":
         remap_topics: list[str] = conf["remap"].split(",")
         for topic in remap_topics:
-            if topic.startswith("/"):
-                remap_set.add(f"{topic}:=/unused{topic}")
-    if len(remap_set) != 1:
-        play_cmd.extend(list(remap_set))
+            if topic.startswith("/") and topic not in remap_list:
+                remap_list.append(f"{topic}:=/unused{topic}")
+    if len(remap_list) != 1:
+        play_cmd.extend(remap_list)
     bag_player = (
         ExecuteProcess(
             cmd=play_cmd,
@@ -391,7 +391,7 @@ def launch_bag_player(
         if conf["record_only"] == "true"
         else ExecuteProcess(cmd=play_cmd, output="screen")
     )
-    return [bag_player, LogInfo(msg=f"The displayed topics are remapped {remap_set}")]
+    return [bag_player, LogInfo(msg=f"remap_command is {remap_list}")]
 
 
 def launch_bag_recorder(context: LaunchContext) -> list:


### PR DESCRIPTION
## Types of PR

- [x] New Features

## Description

- Allow users to add bag play remap with argument `remap`

```shell
# usage. for example remap gnss topics
❯ ros2 launch driving_log_replayer_v2 driving_log_replayer_v2.launch.py scenario_path:=$HOME/dlr2_data/localization/unlabeled.yaml remap:=/sensing/gnss/ublox/fix_velocity,/sensing/gnss/ublox/nav_sat_fix
```

It shows what is being remapped.
See remap_command is ['--remap',  ...]

driving_log_replayer adds the topic to be remapped according to the use case, and the topic to be remapped specified by the user is displayed.

```shell
# launch command sample
[INFO] [launch]: All log files can be found below /home/hyt/.ros/log/2024-11-07-16-52-56-190738-dpc2405001-1683141
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [launch.user]: t4_dataset_path=PosixPath('/home/hyt/dlr2_data/localization/bag_only_dataset'), dataset_index=0, output_dir=PosixPath('/home/hyt/dlr2_data/localization/out/2024-1107-165256'), use_case=localization
[INFO] [launch.user]: check_launch_component(conf)={'sensing': 'true', 'localization': 'true', 'perception': 'false', 'planning': 'false', 'control': 'false'}
[INFO] [launch.user]: conf.get('initial_pose')='{"position": {"x": 3839.340576171875, "y": 73731.3359375, "z": 19.639482498168945}, "orientation": {"x": -0.023971009814459248, "y": 0.005891999600528019, "z": -0.9709848597542231, "w": 0.237863568369043}}', conf.get('direct_initial_pose')=None
[INFO] [launch.user]: conf.get('goal_pose')=None
1730965983.766603 [77]       ros2: determined eno1 (udp/10.0.6.231) as highest quality interface, selected for automatic interface.
[WARNING] [launch_ros.actions.node]: Parameter file path is not a file: /home/hyt/ros_ws/unlabeled/install/individual_params/share/individual_params/config/default/pacmod/pacmod_extra.param.yaml
[INFO] [launch.user]: remap_command is ['--remap', '/sensing/lidar/concatenated/pointcloud:=/unused/concatenated/pointcloud', '/tf:=/unused/tf', '/localization/kinematic_state:=/unused/localization/kinematic_state', '/localization/acceleration:=/unused/localization/acceleration', '/sensing/gnss/ublox/fix_velocity:=/unused/sensing/gnss/ublox/fix_velocity', '/sensing/gnss/ublox/nav_sat_fix:=/unused/sensing/gnss/ublox/nav_sat_fix']
```


## How to review this PR

## Others
