### PR TITLE
feat: set use_aeb_autoware_state_check

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch_config.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch_config.py
@@ -192,7 +192,7 @@ PLANNING_CONTROL_AUTOWARE_DISABLE = {
     "localization": "false",
 }
 
-PLANNING_CONTROL_AUTOWARE_ARGS = {}
+PLANNING_CONTROL_AUTOWARE_ARGS = {"use_aeb_autoware_state_check": "false"}
 
 PLANNING_CONTROL_NODE_PARAMS = {}
 


### PR DESCRIPTION
## Types of PR

- [x] New Features

## Description

When testing aeb, it is absolutely use_aeb_autoware_state_check:=false, so it is automatically set in launch in driving_log_replayer_v2

## How to review this PR

1. use pilot-auto main
2. replace universe with https://github.com/tier4/autoware.universe/tree/feat/set-global-param-for-aeb-state-check
3. replace launch with https://github.com/autowarefoundation/autoware_launch/pull/1218
4. use driving_log_replayer_v2 https://github.com/tier4/driving_log_replayer_v2/tree/feat/aeb-state-check

```shell
ros2 launch driving_log_replayer_v2 driving_log_replayer_v2.launch.py scenario_path:=${your_planning_control_scenario}
```


I checked AEB deubg marker published like the attached picture.

<img width="1400" alt="2024-11-08_14-50" src="https://github.com/user-attachments/assets/fc6c63db-2624-4363-8eda-1949b8af5b5b">

## Others
