### PR TITLE
feat: use cmd sleep for delay

### DIFF
--- a/driving_log_replayer_v2/launch/driving_log_replayer_v2.launch.py
+++ b/driving_log_replayer_v2/launch/driving_log_replayer_v2.launch.py
@@ -365,8 +365,6 @@ def launch_bag_player(
         "bag",
         "play",
         conf["input_bag"],
-        "--delay",
-        conf["play_delay"],
         "--rate",
         conf["play_rate"],
         "--clock",
@@ -428,7 +426,8 @@ def launch_bag_player(
         if conf["record_only"] == "true"
         else ExecuteProcess(cmd=play_cmd, output="screen")
     )
-    return [bag_player, LogInfo(msg=f"remap_command is {remap_list}")]
+    delay_player = ExecuteProcess(cmd=["sleep", conf["play_delay"]], on_exit=[bag_player])
+    return [delay_player, LogInfo(msg=f"remap_command is {remap_list}")]
 
 
 def launch_bag_recorder(context: LaunchContext) -> list:


### PR DESCRIPTION
## Types of PR

- [x] New Features

## Description

- use sleep and on_exit bag play

## How to review this PR

```shell
git checkout feat/bag-play-delay-using-sleep
ros2 launch driving_log_replayer_v2 driving_log_replayer_v2.launch.py scenario_path:=${your_scenario}
```

### before

`/clock` is published before topics in bag play replaying.

https://github.com/user-attachments/assets/cded08b9-5e81-4968-941a-d9a650845041

### after

`/clock` is published same timing as topics in bag published.

https://github.com/user-attachments/assets/e1ee8585-35c2-4a48-a766-969445dc16b4


## Others

closes: #49
