### PR TITLE
fix: convert int value to float

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/pose.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/pose.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+from typing import Any
 
 from geometry_msgs.msg import Point
 from geometry_msgs.msg import Pose
@@ -23,8 +24,23 @@ import numpy as np
 from std_msgs.msg import Header
 
 
+def convert_to_float(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        return {k: convert_to_float(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [convert_to_float(v) for v in obj]
+    if isinstance(obj, int | float):
+        return float(obj)
+    return obj
+
+
+def pose_str_to_dict(pose_str: str) -> dict:
+    pose_dict_number = json.loads(pose_str)
+    return convert_to_float(pose_dict_number)
+
+
 def arg_to_initial_pose(pose_str: str) -> PoseWithCovarianceStamped:
-    pose_dict = json.loads(pose_str)
+    pose_dict = pose_str_to_dict(pose_str)
     covariance = np.array(
         [
             0.25,
@@ -76,7 +92,7 @@ def arg_to_initial_pose(pose_str: str) -> PoseWithCovarianceStamped:
 
 
 def arg_to_goal_pose(pose_str: str) -> Pose:
-    pose_dict = json.loads(pose_str)
+    pose_dict = pose_str_to_dict(pose_str)
     return Pose(
         position=Point(**pose_dict["position"]),
         orientation=Quaternion(**pose_dict["orientation"]),

--- a/driving_log_replayer_v2/test/unittest/test_pose.py
+++ b/driving_log_replayer_v2/test/unittest/test_pose.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 TIER IV.inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from driving_log_replayer_v2.pose import pose_str_to_dict
 
 

--- a/driving_log_replayer_v2/test/unittest/test_pose.py
+++ b/driving_log_replayer_v2/test/unittest/test_pose.py
@@ -1,0 +1,13 @@
+from driving_log_replayer_v2.pose import pose_str_to_dict
+
+
+def test_pose_str_to_dict() -> None:
+    pose_str = (
+        '{"position": {"x": 1, "y": 2, "z": 3}, "orientation": {"x": 0, "y": 0, "z": 0, "w": 1}}'
+    )
+
+    pose_dict = pose_str_to_dict(pose_str)
+    assert pose_dict == {
+        "position": {"x": 1.0, "y": 2.0, "z": 3.0},
+        "orientation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0},
+    }


### PR DESCRIPTION
## Types of PR

- [x] Bugfix

## Description

Address issue with decimals being cast as integers in Autoware Evaluator's scenario editor
Force an integer to be cast to a float

## How to review this PR

The dataset used for testing is TIER IV internal data.

```shell
ros2 launch driving_log_replayer_v2 driving_log_replayer_v2.launch.py scenario_path:=$HOME/dlr2_data/all_component.yaml record_only:=true t4_dataset_path:=/home/hayatomizushima/.webauto/simulation/data/t4_dataset/prd_jt/f7effc57-f53a-41c9-9b8f-15c324dcda88/5/8599869c-ab32-4846-bd01-a220210f6c65/0 t4_dataset_id:=8599869c-ab32-4846-bd01-a220210f6c65 localization:=true planning:=true control:=true
```

before

```shell
[goal_pose_node.py-119]     position=Point(**pose_dict["position"]),
[goal_pose_node.py-119]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/geometry_msgs/msg/_point.py", line 83, in __init__
[goal_pose_node.py-119]     self.z = kwargs.get('z', float())
[goal_pose_node.py-119]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/geometry_msgs/msg/_point.py", line 165, in z
[goal_pose_node.py-119]     assert \
[goal_pose_node.py-119] AssertionError: The 'z' field must be of type 'float'
```

after

GOAL is set and the route is drawn.

## Others
