### PR TITLE
feat(traffic_light): change the topic to save

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/traffic_light.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/traffic_light.py
@@ -17,8 +17,9 @@ from launch.substitutions import LaunchConfiguration
 
 RECORD_TOPIC = """^/tf$\
 |^/diagnostics$\
-|^/sensing/camera/camera[67]/image_raw/compressed$\
 |^/perception/.*/traffic_signals$\
+|^/perception/traffic_light_recognition/traffic_signals/markers$\
+|^/perception/traffic_light_recognition/.*/debug/rois/compressed$\
 |^/driving_log_replayer_v2/.*\
 """
 


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [x] Upgrade of existing features
- [ ] Bugfix

## Description
This PR change the topic to save in traffic_light. We cannot analyze from result using current topic to save, so I change to the topic which we can analyze.

- `/perception/traffic_light_recognition/traffic_signals/markers`      : the result of `autoware_traffic_light_map_visualizer`
- `/perception/traffic_light_recognition/.*/debug/rois/compressed` : the result of `autoware_traffic_light_roi_visualizer`
ref: https://github.com/autowarefoundation/autoware.universe/tree/main/perception/autoware_traffic_light_visualization


## How to review this PR
https://evaluation.ci.tier4.jp/evaluation/reports/fde6df31-c7ab-58b2-baa7-737c17aa4591?project_id=prd_jt

## Others
