### PR TITLE
docs: add instructions for importing nightly

### DIFF
--- a/docs/quick_start/installation.en.md
+++ b/docs/quick_start/installation.en.md
@@ -52,19 +52,26 @@ This document contains step-by-step instruction on how to build [AWF Autoware Co
    vcs import src < simulator.repos
    ```
 
-4. Update rosdep:
+4. (Optional) Basically, the main branch of driving_log_replayer_v2 is intended to be used with the latest autoware, so import nightly.repos as needed.
+
+   ```shell
+   vcs import src < autoware-nightly.repos
+   vcs import src < tools-nightly.repos
+   ```
+
+5. Update rosdep:
 
    ```shell
    rosdep update
    ```
 
-5. Install dependent ROS packages:
+6. Install dependent ROS packages:
 
    ```shell
    rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
    ```
 
-6. Build the workspace:
+7. Build the workspace:
 
    ```shell
    colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release

--- a/docs/quick_start/installation.ja.md
+++ b/docs/quick_start/installation.ja.md
@@ -52,19 +52,26 @@
    vcs import src < simulator.repos
    ```
 
-4. 依存解決のために rosdep を更新する:
+4. (Optional) 基本的にdriving_log_replayer_v2のmainブランチは最新のautowareと共に利用することを前提としているため、必要に応じてnightly.reposをimportする
+
+   ```shell
+   vcs import src < autoware-nightly.repos
+   vcs import src < tools-nightly.repos
+   ```
+
+5. 依存解決のために rosdep を更新する:
 
    ```shell
    rosdep update
    ```
 
-5. rosdep で依存のパッケージをインストールする:
+6. rosdep で依存のパッケージをインストールする:
 
    ```shell
    rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
    ```
 
-6. ワークスペースをビルドする:
+7. ワークスペースをビルドする:
 
    ```shell
    colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [x] Upgrade of existing features
- [ ] Bugfix

## Description

Due to yesterday's pull request 

- https://github.com/tier4/driving_log_replayer_v2/pull/109

we have to use driving_log_replayer_v2 with the latest autoware_tools.

This pull request adds instructions for importing `nightly.repos`.

## How to review this PR

## Others
