### PR TITLE
feat(perception): check pass/fail even if post-process is fail

### DIFF
--- a/driving_log_replayer_v2/launch/post_process.launch.py
+++ b/driving_log_replayer_v2/launch/post_process.launch.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from os.path import expandvars
 from pathlib import Path
 import shutil
 
@@ -47,8 +48,14 @@ def post_process(context: LaunchContext) -> list:
         return [LogInfo(msg="run localization analysis."), localization_analysis]
 
     if conf["use_case"] == "perception":
+        absolute_result_json_path = Path(
+            expandvars(context.launch_configurations["result_json_path"])
+        )
 
         def _run_perception_and_replace_rosbag(context: LaunchContext) -> list:
+            absolute_result_json_path.parent.joinpath(
+                absolute_result_json_path.stem + ".jsonl"
+            ).unlink()
             evaluate(
                 context.launch_configurations["scenario_path"],
                 context.launch_configurations["result_bag_path"],


### PR DESCRIPTION
## Types of PR

- [x] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix

## Description

This PR enables to check pass/fail even if post-process is fail.

Before implementation, if post-process in perception is fail, Evaluator output pass because remain the jsonl which is produced by record_only mode driving_log_replayer_v2

## How to review this PR

https://evaluation.ci.tier4.jp/evaluation/reports/dc1001df-daa8-5ed3-9d56-384277f5eb5f?project_id=prd_jt

And, I check this PR remove the jsonl file (comment out the post-process)

## Others
