### PR TITLE
fix: add `/localization/acceleration` into the record topic list

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/localization.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/localization.py
@@ -25,6 +25,7 @@ RECORD_TOPIC = """^/tf$\
 |^/localization/pose_estimator/pose$\
 |^/localization/pose_estimator/pose_with_covariance$\
 |^/localization/kinematic_state$\
+|^/localization/acceleration$\
 |^/localization/reference_kinematic_state$\
 |^/localization/util/downsample/pointcloud$\
 |^/localization/pose_estimator/points_aligned$\


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [x] Upgrade of existing features
- [ ] Bugfix

## Description

To parse `/localization/acceleration` in the scripts of `autoware_localization_evaluation_scripts`, this pull request add the topic to the record topic list.

- https://github.com/autowarefoundation/autoware_tools/pull/237

## How to review this PR

See

- https://github.com/autowarefoundation/autoware_tools/pull/237

## Others
