### PR TITLE
feat(perception): regular expression and the way to represent None

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/perception.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/perception.py
@@ -66,7 +66,7 @@ USE_CASE_ARGS: list[DeclareLaunchArgument] = [
     DeclareLaunchArgument(
         "evaluation_tracking_topic_regex",
         default_value=EVALUATION_TRACKING_TOPIC_REGEX,
-        description="Regex pattern for evaluation tracking topic name. Must start with '^' and end with '$'. Wildcards (e.g. '.*', '+', '?', '[...]') are not allowed. If you do not want to use this feature, set it to '' or  None'.",
+        description="Regex pattern for evaluation tracking topic name. Must start with '^' and end with '$'. Wildcards (e.g. '.*', '+', '?', '[...]') are not allowed. If you do not want to use this feature, set it to '' or 'None'.",
     ),
     DeclareLaunchArgument(
         "evaluation_prediction_topic_regex",

--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/perception.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/perception.py
@@ -37,37 +37,45 @@ AUTOWARE_ARGS = {}
 
 NODE_PARAMS = {}
 
+EVALUATION_DETECTION_TOPIC_REGEX = """\
+^/perception/object_recognition/detection/objects$\
+|^/perception/object_recognition/detection/centerpoint/objects$\
+|^/perception/object_recognition/detection/centerpoint/validation/objects$\
+|^/perception/object_recognition/detection/clustering/objects$\
+|^/perception/object_recognition/detection/detection_by_tracker/objects$\
+|^/perception/object_recognition/detection/objects_before_filter$\
+"""
+
+EVALUATION_TRACKING_TOPIC_REGEX = """\
+^/perception/object_recognition/tracking/objects$\
+"""
+
+EVALUATION_PREDICTION_TOPIC_REGEX = """\
+^/perception/object_recognition/objects$\
+"""
+
+EVALUATION_FP_VALIDATION_TOPIC_REGEX = """\
+"""
+
 USE_CASE_ARGS: list[DeclareLaunchArgument] = [
     DeclareLaunchArgument(
         "evaluation_detection_topic_regex",
-        default_value="""\
-            |^/perception/object_recognition/detection/objects$\
-            |^/perception/object_recognition/detection/centerpoint/objects$\
-            |^/perception/object_recognition/detection/centerpoint/validation/objects$\
-            |^/perception/object_recognition/detection/clustering/objects$\
-            |^/perception/object_recognition/detection/detection_by_tracker/objects$\
-            |^/perception/object_recognition/detection/objects_before_filter$\
-        """,
-        description="Regex pattern for evaluation detection topic name. Must start with '^' and end with '$'. Wildcards (e.g. '.*', '+', '?', '[...]') are not allowed.",
+        default_value=EVALUATION_DETECTION_TOPIC_REGEX,
+        description="Regex pattern for evaluation detection topic name. Must start with '^' and end with '$'. Wildcards (e.g. '.*', '+', '?', '[...]') are not allowed. If you do not want to use this feature, set it to '' or 'None'.",
     ),
     DeclareLaunchArgument(
         "evaluation_tracking_topic_regex",
-        default_value="""\
-            |^/perception/object_recognition/tracking/objects$\
-        """,
-        description="Regex pattern for evaluation tracking topic name. Must start with '^' and end with '$'. Wildcards (e.g. '.*', '+', '?', '[...]') are not allowed.",
+        default_value=EVALUATION_TRACKING_TOPIC_REGEX,
+        description="Regex pattern for evaluation tracking topic name. Must start with '^' and end with '$'. Wildcards (e.g. '.*', '+', '?', '[...]') are not allowed. If you do not want to use this feature, set it to '' or  None'.",
     ),
     DeclareLaunchArgument(
         "evaluation_prediction_topic_regex",
-        default_value="""\
-            |^/perception/object_recognition/objects$\
-        """,
-        description="Regex pattern for evaluation prediction topic name. Must start with '^' and end with '$'. Wildcards (e.g. '.*', '+', '?', '[...]') are not allowed.",
+        default_value=EVALUATION_PREDICTION_TOPIC_REGEX,
+        description="Regex pattern for evaluation prediction topic name. Must start with '^' and end with '$'. Wildcards (e.g. '.*', '+', '?', '[...]') are not allowed. If you do not want to use this feature, set it to '' or 'None'.",
     ),
     DeclareLaunchArgument(
         "evaluation_fp_validation_topic_regex",
-        default_value="""\
-        """,
-        description="Regex pattern for evaluation fp_validation topic name. Must start with '^' and end with '$'. Wildcards (e.g. '.*', '+', '?', '[...]') are not allowed.",
+        default_value=EVALUATION_FP_VALIDATION_TOPIC_REGEX,
+        description="Regex pattern for evaluation fp_validation topic name. Must start with '^' and end with '$'. Wildcards (e.g. '.*', '+', '?', '[...]') are not allowed. If you do not want to use this feature, set it to '' or 'None'.",
     ),
 ]

--- a/driving_log_replayer_v2/driving_log_replayer_v2/perception/runner.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/perception/runner.py
@@ -286,27 +286,23 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--evaluation-detection-topic-regex",
-        default="""\
-        """,
-        help="Regex pattern for evaluation detection topic name. Must start with '^' and end with '$'. Wildcards (e.g. '.*', '+', '?', '[...]') are not allowed.",
+        default="",
+        help="Regex pattern for evaluation detection topic name. Must start with '^' and end with '$'. Wildcards (e.g. '.*', '+', '?', '[...]') are not allowed. If you do not want to use this feature, set it to '' or 'None'.",
     )
     parser.add_argument(
         "--evaluation-tracking-topic-regex",
-        default="""\
-        """,
-        help="Regex pattern for evaluation tracking topic name. Must start with '^' and end with '$'. Wildcards (e.g. '.*', '+', '?', '[...]') are not allowed.",
+        default="",
+        help="Regex pattern for evaluation tracking topic name. Must start with '^' and end with '$'. Wildcards (e.g. '.*', '+', '?', '[...]') are not allowed. If you do not want to use this feature, set it to '' or 'None'.",
     )
     parser.add_argument(
         "--evaluation-prediction-topic-regex",
-        default="""\
-        """,
-        help="Regex pattern for evaluation prediction topic name. Must start with '^' and end with '$'. Wildcards (e.g. '.*', '+', '?', '[...]') are not allowed.",
+        default="",
+        help="Regex pattern for evaluation prediction topic name. Must start with '^' and end with '$'. Wildcards (e.g. '.*', '+', '?', '[...]') are not allowed. If you do not want to use this feature, set it to '' or 'None'.",
     )
     parser.add_argument(
         "--evaluation-fp-validation-topic-regex",
-        default="""\
-        """,
-        help="Regex pattern for evaluation fp_validation topic name. Must start with '^' and end with '$'. Wildcards (e.g. '.*', '+', '?', '[...]') are not allowed.",
+        default="",
+        help="Regex pattern for evaluation fp_validation topic name. Must start with '^' and end with '$'. Wildcards (e.g. '.*', '+', '?', '[...]') are not allowed. If you do not want to use this feature, set it to '' or 'None'.",
     )
     return parser.parse_args()
 

--- a/driving_log_replayer_v2/driving_log_replayer_v2/perception/topics.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/perception/topics.py
@@ -23,22 +23,24 @@ def convert_topic_list_from_regex_str(record_topic_str: str) -> list[str]:
     Raises ValueError if a pattern contains wildcards or special regex syntax.
     """
     topics = []
-    for raw in record_topic_str.strip().split("|"):
-        line = raw.strip().rstrip("\\")
-        if not line:
-            continue
+    if record_topic_str in ("", "None"):
+        return topics
 
-        # Raise error if line contains any special regex characters except ^ and $
+    for raw in record_topic_str.split("|"):
+        # remove trailing backslash
+        line = raw.rstrip("\\")
+
+        # raise error if line contains any special regex characters except ^ and $
         if re.search(r"[.*+?[\](){}|]", line):
             err_msg = f"Invalid wildcard or regex syntax found in topic regex: '{line}'"
             raise ValueError(err_msg)
 
-        # Enforce ^...$ form
+        # enforce ^...$ form
         if not (line.startswith("^") and line.endswith("$")):
             err_msg = f"Regex must start with '^' and end with '$': '{line}'"
             raise ValueError(err_msg)
 
-        # Normalize to ROS topic
+        # remove the leading ^ and trailing $ from the regex
         line = re.sub(r"^\^/?", "/", line)
         line = re.sub(r"\$$", "", line)
         topics.append(line)


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [x] Upgrade of existing features
- [ ] Bugfix

## Description

This PR changes treat about empty string.

Regarding ROS 2 launch (like terminal), cannnot use empty string like `ros2 launch xxx xxx.launch.xml  parameter:=""`. So I allow to use "None" instead of "".

And previous code had spaces and line breaks so I modify it.

## How to review this PR

you can see https://github.com/tier4/pilot-auto/pull/1352

## Others
