### PR TITLE
fix(perception): change args `False` to `True` to save `scene_result.pkl`

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/perception/manager.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/perception/manager.py
@@ -128,4 +128,4 @@ class EvaluationManager:
 
     def evaluate_all_frames(self) -> None:
         for _, evaluator in self._evaluators.items():
-            evaluator.evaluate_all_frames(save_frame_results=False)
+            evaluator.evaluate_all_frames(save_frame_results=True)


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Description

This PR get to change args `False` to `True` to save `scene_result.pkl`. (I made mistake in [this PR here](https://github.com/tier4/driving_log_replayer_v2/pull/143/files#diff-08f8b1136b01f45642920ce9d213c3917a76a43456c772bdf7bd9b8908bb1260))

## How to review this PR

## Others
