### PR TITLE
chore: add unknown label

### DIFF
--- a/sample/perception/scenario.criteria.custom.yaml
+++ b/sample/perception/scenario.criteria.custom.yaml
@@ -19,33 +19,33 @@ Evaluation:
   PerceptionEvaluationConfig:
     evaluation_config_dict:
       evaluation_task: detection # detection or tracking. Evaluate the objects specified here
-      target_labels: [car, bicycle, pedestrian, motorbike] # evaluation label
+      target_labels: [car, bicycle, pedestrian, motorbike, unknown] # evaluation label
       max_x_position: 102.4 # Maximum x position of object to be evaluated
       max_y_position: 102.4 # Maximum y position of object to be evaluated
       # max_distance: null # Maximum distance from the base_link of the object to be evaluated. Exclusive use with max_x_potion, max_y_position.
       # min_distance: null # Minimum distance from the base_link of the object to be evaluated. Exclusive use with max_x_potion, max_y_position.
       # confidence_threshold: null # Threshold of confidence for the estimated object to be evaluated
       # target_uuids: null # If you want to evaluate only specific ground truths, specify the UUIDs of the ground truths to be evaluated. If null, use all
-      max_matchable_radii: [5.0, 3.0, 3.0, 3.0]
+      max_matchable_radii: [5.0, 3.0, 3.0, 3.0, 3.0]
       merge_similar_labels: false # Whether or not to merge similar labels https://github.com/tier4/autoware_perception_evaluation/blob/develop/docs/en/perception/label.md#merge-similar-labels-option
       allow_matching_unknown: true # Whether or not to match objects whose labels are unknown
       ignore_attributes: [cycle_state.without_rider] # ignore labels with the specified attribute, name in attribute.json of t4_dataset
-      center_distance_thresholds: [[1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 2.0, 2.0]] # Threshold for center-to-center distance [m] matching
+      center_distance_thresholds: [[1.0, 1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 2.0, 2.0, 2.0]] # Threshold for center-to-center distance [m] matching
       plane_distance_thresholds: [2.0, 30.0] # Threshold for planar distance matching
       iou_2d_thresholds: [0.5] # Threshold for 2D IoU
       iou_3d_thresholds: [0.5] # Threshold for 3D IoU
-      min_point_numbers: [0, 0, 0, 0] # Minimum number of point clouds in bounding box for ground truth object. If min_point_numbers=0, all ground truth objects are evaluated
+      min_point_numbers: [0, 0, 0, 0, 0] # Minimum number of point clouds in bounding box for ground truth object. If min_point_numbers=0, all ground truth objects are evaluated
   CriticalObjectFilterConfig:
-    target_labels: [car, bicycle, pedestrian, motorbike]
+    target_labels: [car, bicycle, pedestrian, motorbike, unknown]
     ignore_attributes: [cycle_state.without_rider]
-    max_x_position_list: [30.0, 30.0, 30.0, 30.0]
-    max_y_position_list: [30.0, 30.0, 30.0, 30.0]
+    max_x_position_list: [30.0, 30.0, 30.0, 30.0, 30.0]
+    max_y_position_list: [30.0, 30.0, 30.0, 30.0, 30.0]
     # max_distance_list: null
     # min_distance_list: null
     # min_point_numbers: [0, 0, 0, 0]
     # confidence_threshold_list: null
     # target_uuids: null
   PerceptionPassFailConfig:
-    target_labels: [car, bicycle, pedestrian, motorbike]
-    matching_threshold_list: [2.0, 2.0, 2.0, 2.0] # Threshold for planar distance matching
+    target_labels: [car, bicycle, pedestrian, motorbike, unknown]
+    matching_threshold_list: [2.0, 2.0, 2.0, 2.0, 2.0] # Threshold for planar distance matching
     # confidence_threshold_list: null

--- a/sample/perception/scenario.fp.ja.yaml
+++ b/sample/perception/scenario.fp.ja.yaml
@@ -24,16 +24,16 @@ Evaluation:
   PerceptionEvaluationConfig:
     evaluation_config_dict:
       evaluation_task: fp_validation # detection/tracking/prediction/fp_validation ここで指定したobjectsを評価する
-      target_labels: [car, bicycle, pedestrian, motorbike] # 評価ラベル
+      target_labels: [car, bicycle, pedestrian, motorbike, unknown] # 評価ラベル
       max_x_position: 102.4 # 評価対象 object の最大 x 位置
       max_y_position: 102.4 # 評価対象 object の最大 y 位置
-      max_matchable_radii: [5.0, 3.0, 3.0, 3.0]
+      max_matchable_radii: [5.0, 3.0, 3.0, 3.0, 3.0]
       merge_similar_labels: false # Whether or not to merge similar labels https://github.com/tier4/autoware_perception_evaluation/blob/develop/docs/en/perception/label.md#merge-similar-labels-option
       allow_matching_unknown: true # Whether or not to match objects whose labels are unknown
   CriticalObjectFilterConfig: # 必ず検出できてほしいオブジェクトに対する config
-    target_labels: [car, bicycle, pedestrian, motorbike]
-    max_x_position_list: [100.0, 100.0, 100.0, 100.0]
-    max_y_position_list: [100.0, 100.0, 100.0, 100.0]
+    target_labels: [car, bicycle, pedestrian, motorbike, unknown]
+    max_x_position_list: [100.0, 100.0, 100.0, 100.0, 100.0]
+    max_y_position_list: [100.0, 100.0, 100.0, 100.0, 100.0]
   PerceptionPassFailConfig: # Pass fail を決める config
-    target_labels: [car, bicycle, pedestrian, motorbike]
-    matching_threshold_list: [2.0, 2.0, 2.0, 2.0] # 平面距離マッチング時の閾値
+    target_labels: [car, bicycle, pedestrian, motorbike, unknown]
+    matching_threshold_list: [2.0, 2.0, 2.0, 2.0, 2.0] # 平面距離マッチング時の閾値

--- a/sample/perception/scenario.fp.yaml
+++ b/sample/perception/scenario.fp.yaml
@@ -24,16 +24,16 @@ Evaluation:
   PerceptionEvaluationConfig:
     evaluation_config_dict:
       evaluation_task: fp_validation # detection, tracking, prediction, or fp_validation. Evaluate the objects specified here
-      target_labels: [car, bicycle, pedestrian, motorbike] # evaluation label
+      target_labels: [car, bicycle, pedestrian, motorbike, unknown] # evaluation label
       max_x_position: 102.4 # Maximum x position of object to be evaluated
       max_y_position: 102.4 # Maximum y position of object to be evaluated
-      max_matchable_radii: [5.0, 3.0, 3.0, 3.0]
+      max_matchable_radii: [5.0, 3.0, 3.0, 3.0, 3.0]
       merge_similar_labels: false # Whether or not to merge similar labels https://github.com/tier4/autoware_perception_evaluation/blob/develop/docs/en/perception/label.md#merge-similar-labels-option
       allow_matching_unknown: true # Whether or not to match objects whose labels are unknown
   CriticalObjectFilterConfig:
-    target_labels: [car, bicycle, pedestrian, motorbike]
-    max_x_position_list: [100.0, 100.0, 100.0, 100.0]
-    max_y_position_list: [100.0, 100.0, 100.0, 100.0]
+    target_labels: [car, bicycle, pedestrian, motorbike, unknown]
+    max_x_position_list: [100.0, 100.0, 100.0, 100.0, 100.0]
+    max_y_position_list: [100.0, 100.0, 100.0, 100.0, 100.0]
   PerceptionPassFailConfig:
-    target_labels: [car, bicycle, pedestrian, motorbike]
-    matching_threshold_list: [2.0, 2.0, 2.0, 2.0] # Threshold for planar distance matching
+    target_labels: [car, bicycle, pedestrian, motorbike, unknown]
+    matching_threshold_list: [2.0, 2.0, 2.0, 2.0, 2.0] # Threshold for planar distance matching

--- a/sample/perception/scenario.ja.yaml
+++ b/sample/perception/scenario.ja.yaml
@@ -30,33 +30,33 @@ Evaluation:
   PerceptionEvaluationConfig:
     evaluation_config_dict:
       evaluation_task: detection # detection/tracking/prediction ここで指定したobjectsを評価する
-      target_labels: [car, bicycle, pedestrian, motorbike] # 評価ラベル
+      target_labels: [car, bicycle, pedestrian, motorbike, unknown] # 評価ラベル
       max_x_position: 102.4 # 評価対象 object の最大 x 位置
       max_y_position: 102.4 # 評価対象 object の最大 y 位置
       # max_distance: null # 評価対象 object の base_link からの最大距離、max_x_potion, max_y_positionと排他利用、この例ではこちらはnull
       # min_distance: null # 評価対象 object の base_link からの最小距離、max_x_potion, max_y_positionと排他利用、この例ではこちらはnull
       # confidence_threshold: null # 評価対象の estimated object の confidence の閾値
       # target_uuids: null # 特定の ground truth のみに対して評価を行いたい場合，対象とする ground truth の UUID を指定する。nullなら全てが対象
-      max_matchable_radii: [5.0, 3.0, 3.0, 3.0]
+      max_matchable_radii: [5.0, 3.0, 3.0, 3.0, 3.0]
       merge_similar_labels: false # 類似のラベルをマージするか https://github.com/tier4/autoware_perception_evaluation/blob/develop/docs/ja/perception/label.md#%E9%A1%9E%E4%BC%BC%E3%83%A9%E3%83%99%E3%83%AB%E3%81%AE%E3%83%9E%E3%83%BC%E3%82%B8
       allow_matching_unknown: true # ラベルがunknownのオブジェクトとマッチングさせるか
       ignore_attributes: [cycle_state.without_rider] # 指定した属性を持つラベルを無視する。t4_datasetのattribute.jsonのnameを指定する
-      center_distance_thresholds: [[1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 2.0, 2.0]] # 中心間距離マッチング時の閾値
+      center_distance_thresholds: [[1.0, 1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 2.0, 2.0, 2.0]] # 中心間距離マッチング時の閾値
       plane_distance_thresholds: [2.0, 30.0] # 平面距離マッチング時の閾値
       iou_2d_thresholds: [0.5] # 2D IoU マッチング時の閾値
       iou_3d_thresholds: [0.5] # 3D IoU マッチング時の閾値
       min_point_numbers: [0, 0, 0, 0] # ground truth object における，bbox 内の最小点群数．min_point_numbers=0 の場合は，全 ground truth object を評価
   CriticalObjectFilterConfig: # 必ず検出できてほしいオブジェクトに対する config
-    target_labels: [car, bicycle, pedestrian, motorbike]
+    target_labels: [car, bicycle, pedestrian, motorbike, unknown]
     ignore_attributes: [cycle_state.without_rider]
-    max_x_position_list: [30.0, 30.0, 30.0, 30.0]
-    max_y_position_list: [30.0, 30.0, 30.0, 30.0]
+    max_x_position_list: [30.0, 30.0, 30.0, 30.0, 30.0]
+    max_y_position_list: [30.0, 30.0, 30.0, 30.0, 30.0]
     # max_distance_list: null
     # min_distance_list: null
     # min_point_numbers: [0, 0, 0, 0]
     # confidence_threshold_list: null
     # target_uuids: null
   PerceptionPassFailConfig: # Pass fail を決める config
-    target_labels: [car, bicycle, pedestrian, motorbike]
-    matching_threshold_list: [2.0, 2.0, 2.0, 2.0] # 平面距離マッチング時の閾値
+    target_labels: [car, bicycle, pedestrian, motorbike, unknown]
+    matching_threshold_list: [2.0, 2.0, 2.0, 2.0, 2.0] # 平面距離マッチング時の閾値
     # confidence_threshold_list: null

--- a/sample/perception/scenario.yaml
+++ b/sample/perception/scenario.yaml
@@ -30,7 +30,7 @@ Evaluation:
   PerceptionEvaluationConfig:
     evaluation_config_dict:
       evaluation_task: detection # detection, tracking or prediction. Evaluate the objects specified here
-      target_labels: [car, bicycle, pedestrian, motorbike] # evaluation label
+      target_labels: [car, bicycle, pedestrian, motorbike, unknown] # evaluation label
       max_x_position: 102.4 # Maximum x position of object to be evaluated
       max_y_position: 102.4 # Maximum y position of object to be evaluated
       # max_distance: null # Maximum distance from the base_link of the object to be evaluated. Exclusive use with max_x_potion, max_y_position.
@@ -41,22 +41,22 @@ Evaluation:
       merge_similar_labels: false # Whether or not to merge similar labels https://github.com/tier4/autoware_perception_evaluation/blob/develop/docs/en/perception/label.md#merge-similar-labels-option
       allow_matching_unknown: true # Whether or not to match objects whose labels are unknown
       ignore_attributes: [cycle_state.without_rider] # ignore labels with the specified attribute, name in attribute.json of t4_dataset
-      center_distance_thresholds: [[1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 2.0, 2.0]] # Threshold for center-to-center distance [m] matching
+      center_distance_thresholds: [[1.0, 1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 2.0, 2.0, 2.0]] # Threshold for center-to-center distance [m] matching
       plane_distance_thresholds: [2.0, 30.0] # Threshold for planar distance matching
       iou_2d_thresholds: [0.5] # Threshold for 2D IoU
       iou_3d_thresholds: [0.5] # Threshold for 3D IoU
       min_point_numbers: [0, 0, 0, 0] # Minimum number of point clouds in bounding box for ground truth object. If min_point_numbers=0, all ground truth objects are evaluated
   CriticalObjectFilterConfig:
-    target_labels: [car, bicycle, pedestrian, motorbike]
+    target_labels: [car, bicycle, pedestrian, motorbike, unknown]
     ignore_attributes: [cycle_state.without_rider]
-    max_x_position_list: [30.0, 30.0, 30.0, 30.0]
-    max_y_position_list: [30.0, 30.0, 30.0, 30.0]
+    max_x_position_list: [30.0, 30.0, 30.0, 30.0, 30.0]
+    max_y_position_list: [30.0, 30.0, 30.0, 30.0, 30.0]
     # max_distance_list: null
     # min_distance_list: null
     # min_point_numbers: [0, 0, 0, 0]
     # confidence_threshold_list: null
     # target_uuids: null
   PerceptionPassFailConfig:
-    target_labels: [car, bicycle, pedestrian, motorbike]
-    matching_threshold_list: [2.0, 2.0, 2.0, 2.0] # Threshold for planar distance matching
+    target_labels: [car, bicycle, pedestrian, motorbike, unknown]
+    matching_threshold_list: [2.0, 2.0, 2.0, 2.0, 2.0] # Threshold for planar distance matching
     # confidence_threshold_list: null

--- a/sample/perception_2d/scenario.ja.yaml
+++ b/sample/perception_2d/scenario.ja.yaml
@@ -21,13 +21,13 @@ Evaluation:
       evaluation_task: detection2d # detection2d # 現時点ではdetection2dにしか対応していない。今後の拡張でtracking2dにも対応予定
       center_distance_thresholds: [100, 200] # 中心間距離マッチング時の閾値。カメラ画像上のピクセルで指定する
       iou_2d_thresholds: [0.5] # 2D IoU マッチング時の閾値
-      target_labels: [car, truck, bicycle, pedestrian, motorbike] # 評価ラベル
+      target_labels: [car, truck, bicycle, pedestrian, motorbike, unknown] # 評価ラベル
       ignore_attributes: [cycle_state.without_rider] # 指定した属性を持つラベルを無視する。t4_datasetのattribute.jsonのnameを指定する
       allow_matching_unknown: true # ラベルがunknownのオブジェクトとマッチングさせるか
       merge_similar_labels: false # 類似のラベルをマージするか https://github.com/tier4/autoware_perception_evaluation/blob/develop/docs/ja/perception/label.md#%E9%A1%9E%E4%BC%BC%E3%83%A9%E3%83%99%E3%83%AB%E3%81%AE%E3%83%9E%E3%83%BC%E3%82%B8
   CriticalObjectFilterConfig:
-    target_labels: [car, truck, bicycle, pedestrian, motorbike] # 評価対象ラベル名
+    target_labels: [car, truck, bicycle, pedestrian, motorbike, unknown] # 評価対象ラベル名
     ignore_attributes: [cycle_state.without_rider] # 指定した属性を持つラベルを無視する。t4_datasetのattribute.jsonのnameを指定する
   PerceptionPassFailConfig:
-    target_labels: [car, truck, bicycle, pedestrian, motorbike]
-    matching_threshold_list: [0.5, 0.5, 0.5, 0.5]
+    target_labels: [car, truck, bicycle, pedestrian, motorbike, unknown]
+    matching_threshold_list: [0.5, 0.5, 0.5, 0.5, 0.5, 0.5]

--- a/sample/perception_2d/scenario.yaml
+++ b/sample/perception_2d/scenario.yaml
@@ -21,13 +21,13 @@ Evaluation:
       evaluation_task: detection2d # detection2d # At present, only detection2d is supported. tracking2d will be supported in future extensions.
       center_distance_thresholds: [100, 200] # Threshold for center-to-center distance [pixel] matching
       iou_2d_thresholds: [0.5] # Threshold for 2D IoU
-      target_labels: [car, truck, bicycle, pedestrian, motorbike] # evaluation label
+      target_labels: [car, truck, bicycle, pedestrian, motorbike, unknown] # evaluation label
       ignore_attributes: [cycle_state.without_rider] # ignore labels with the specified attribute, name in attribute.json of t4_dataset
       allow_matching_unknown: true # Whether or not to match objects whose labels are unknown
       merge_similar_labels: false # Whether or not to merge similar labels https://github.com/tier4/autoware_perception_evaluation/blob/develop/docs/en/perception/label.md#merge-similar-labels-option
   CriticalObjectFilterConfig:
-    target_labels: [car, truck, bicycle, pedestrian, motorbike]
+    target_labels: [car, truck, bicycle, pedestrian, motorbike, unknown]
     ignore_attributes: [cycle_state.without_rider] # ignore labels with the specified attribute, name in attribute.json of t4_dataset
   PerceptionPassFailConfig:
-    target_labels: [car, truck, bicycle, pedestrian, motorbike]
-    matching_threshold_list: [0.5, 0.5, 0.5, 0.5]
+    target_labels: [car, truck, bicycle, pedestrian, motorbike, unknown]
+    matching_threshold_list: [0.5, 0.5, 0.5, 0.5, 0.5, 0.5]


### PR DESCRIPTION
## Types of PR
- [x] Upgrade of existing features

## Description
The new matching algorithm introduced in [PR](https://github.com/tier4/autoware_perception_evaluation/pull/225) enhances our framework significantly. If we opt for `ALLOW_UNKNOWN` as our matching policy, it is essential to specify the 'unknown' label in the target label for optimal performance.

To ensure a seamless integration and maximize the benefits of these improvements, this PR should be merged alongside this crucial [PR](https://github.com/tier4/autoware_perception_evaluation/pull/204).

