### PR TITLE
feat(perception): use function get_num_gt() of perception_eval

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/criteria/perception.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/criteria/perception.py
@@ -295,9 +295,8 @@ class NumGtTP(CriteriaMethodImpl):
     @staticmethod
     def calculate_score(frame: PerceptionFrameResult) -> float:
         num_success: int = frame.pass_fail_result.get_num_success()
-        num_gt: int = len(frame.pass_fail_result.tp_object_results) + len(
-            frame.pass_fail_result.fn_objects,
-        )
+        num_gt: int = frame.pass_fail_result.get_num_gt()
+
         return 100.0 * num_success / num_gt if num_gt != 0 else 100.0
 
     @property


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [x] Upgrade of existing features
- [ ] Bugfix

## Description

This PR enables to use `get_num_gt()` of perception_eval.

perception_eval PR : https://github.com/tier4/autoware_perception_evaluation/pull/228

## How to review this PR

## Others
