### PR TITLE
feat(perception): add key to specify degradation topic

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/perception/models.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/perception/models.py
@@ -141,12 +141,13 @@ class Conditions(BaseModel):
 
 class Evaluation(BaseModel):
     UseCaseName: Literal["perception"]
-    UseCaseFormatVersion: Literal["1.0.0", "1.1.0"]
+    UseCaseFormatVersion: Literal["1.0.0", "1.1.0", "1.2.0"]
     Datasets: list[dict]
     Conditions: Conditions
     PerceptionEvaluationConfig: dict
     CriticalObjectFilterConfig: dict
     PerceptionPassFailConfig: dict
+    degradation_topic: str | None = None
 
 
 class PerceptionScenario(Scenario):

--- a/sample/perception/scenario.fp.ja.yaml
+++ b/sample/perception/scenario.fp.ja.yaml
@@ -21,6 +21,7 @@ Evaluation:
         CriteriaLevel: easy # クライテリアレベル(perfect/hard/normal/easy、もしくはカスタム値0.0〜100.0の数値)
         Filter: #
           Distance: 50.0- # [m] null [距離でフィルタしない] or 下限-(上限) [上限は省略可。省略した場合1.7976931348623157e+308]
+  degradation_topic: /perception/object_recognition/detection/objects # デグレード評価用のトピック。指定しない場合は評価タスクに基づいてトピックを決定する。
   PerceptionEvaluationConfig:
     evaluation_config_dict:
       evaluation_task: fp_validation # detection/tracking/prediction/fp_validation ここで指定したobjectsを評価する

--- a/sample/perception/scenario.fp.yaml
+++ b/sample/perception/scenario.fp.yaml
@@ -21,6 +21,7 @@ Evaluation:
         CriteriaLevel: easy # Level of criteria (perfect/hard/normal/easy, or custom value 0.0-100.0)
         Filter:
           Distance: 50.0- # [m] null [Do not filter by distance] or lower_limit-(upper_limit) [Upper limit can be omitted. If omitted value is 1.7976931348623157e+308]
+  degradation_topic: /perception/object_recognition/detection/objects # Topic for degradation evaluation. If not specified, decide the topic based on the evaluation task.
   PerceptionEvaluationConfig:
     evaluation_config_dict:
       evaluation_task: fp_validation # detection, tracking, prediction, or fp_validation. Evaluate the objects specified here

--- a/sample/perception/scenario.ja.yaml
+++ b/sample/perception/scenario.ja.yaml
@@ -5,7 +5,7 @@ SensorModel: sample_sensor_kit
 VehicleModel: sample_vehicle
 Evaluation:
   UseCaseName: perception
-  UseCaseFormatVersion: 1.1.0
+  UseCaseFormatVersion: 1.2.0
   Datasets:
     - sample_dataset:
         VehicleId: default # データセット毎にVehicleIdを指定する
@@ -27,6 +27,7 @@ Evaluation:
           Region:
             x_position: null # [m] null [x座標でフィルタしない] or 下限,上限
             y_position: null # [m] null [y座標でフィルタしない] or 下限,上限
+  degradation_topic: /perception/object_recognition/detection/objects # デグレード評価用のトピック。指定しない場合は評価タスクに基づいてトピックを決定する。
   PerceptionEvaluationConfig:
     evaluation_config_dict:
       evaluation_task: detection # detection/tracking/prediction ここで指定したobjectsを評価する

--- a/sample/perception/scenario.yaml
+++ b/sample/perception/scenario.yaml
@@ -5,7 +5,7 @@ SensorModel: sample_sensor_kit
 VehicleModel: sample_vehicle
 Evaluation:
   UseCaseName: perception
-  UseCaseFormatVersion: 1.1.0
+  UseCaseFormatVersion: 1.2.0
   Datasets:
     - sample_dataset:
         VehicleId: default # Specify VehicleId for each data set.
@@ -27,6 +27,7 @@ Evaluation:
           Region:
             x_position: null # [m] null [Do not filter by x_position] or lower_limit,upper_limit
             y_position: null # [m] null [Do not filter by y_position] or lower_limit,upper_limit
+  degradation_topic: /perception/object_recognition/detection/objects # Topic for degradation evaluation. If not specified, decide the topic based on the evaluation task.
   PerceptionEvaluationConfig:
     evaluation_config_dict:
       evaluation_task: detection # detection, tracking or prediction. Evaluate the objects specified here


### PR DESCRIPTION
## Types of PR

- [x] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix

## Description

This PR adds key `degradation_topic` to scenario.yaml in order to specify it.

And if specify `fp_validation` as evaluation_task, get to evaluate all topic `detection`, `tracking`, `prediction`.

## How to review this PR

## Others
