### PR TITLE
fix(perception): not evaluation when num gt is 0 instead of num est is 0

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/criteria/perception.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/criteria/perception.py
@@ -233,7 +233,7 @@ class CriteriaMethodImpl(ABC):
 
         Returns:
         -------
-            bool: Whether the frame result has gt objects is.
+            bool: Whether the frame result has gt objects.
 
         """
         return frame.pass_fail_result.get_num_gt() > 0

--- a/driving_log_replayer_v2/driving_log_replayer_v2/criteria/perception.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/criteria/perception.py
@@ -212,8 +212,8 @@ class CriteriaMethodImpl(ABC):
             SuccessFail: Success or fail.
 
         """
-        # No ground truth and No result is considered as Not Available, return None.
-        if self.has_objects(frame) is False:
+        # No ground truth is considered as Not Available, return None.
+        if self.has_gt_objects(frame) is False:
             return None
         score: float = self.calculate_score(frame)
         return (
@@ -223,9 +223,9 @@ class CriteriaMethodImpl(ABC):
         )
 
     @staticmethod
-    def has_objects(frame: PerceptionFrameResult) -> bool:
+    def has_gt_objects(frame: PerceptionFrameResult) -> bool:
         """
-        Return whether the frame result contains at least one objects.
+        Return whether the frame result contains at least one gt objects.
 
         Args:
         ----
@@ -233,12 +233,10 @@ class CriteriaMethodImpl(ABC):
 
         Returns:
         -------
-            bool: Whether the frame result has objects is.
+            bool: Whether the frame result has gt objects is.
 
         """
-        num_success: int = frame.pass_fail_result.get_num_success()
-        num_fail: int = frame.pass_fail_result.get_num_fail()
-        return num_success + num_fail > 0
+        return frame.pass_fail_result.get_num_gt() > 0
 
     @staticmethod
     @abstractmethod


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Description

This PR changes the evaluation condition.

**Current**
Evaluate perception if either est or gt exists.

**This PR**
Evaluate perception if gt exists.

**Reason**
It is normal to evaluate when gt exists and if gt does not exist, it is impossible to do it.
And return value of  `has_objects` is used as `NoGTNoObj` (https://github.com/tier4/driving_log_replayer_v2/blob/fix/no_gt_became_invalid_evaluation/driving_log_replayer_v2/driving_log_replayer_v2/perception/models.py#L175)

## How to review this PR

## Others
