### PR TITLE
fix: obstacle_segmentation_multipolygon

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
@@ -39,7 +39,6 @@ import ros2_numpy
 from rosidl_runtime_py import message_to_ordereddict
 from sensor_msgs.msg import PointCloud2
 from shapely.geometry import Polygon, MultiPolygon
-from typing import Union
 import simplejson as json
 from std_msgs.msg import ColorRGBA
 from std_msgs.msg import Header

--- a/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
@@ -389,13 +389,13 @@ def get_non_detection_area_in_base_link(
     list_p_stamped_base_link: list[PointStamped] = []
     poly: Union[Polygon, MultiPolygon]
     for poly in poly.geoms:
-            for i, shapely_point in enumerate(poly.exterior.coords):
+        for i, shapely_point in enumerate(poly.exterior.coords):
                 if i != len(poly.exterior.coords) - 1:
                     p_stamped_map = PointStamped(
                         header=header,
                         point=Point(x=shapely_point[0], y=shapely_point[1], z=average_z),
                     )
-                    list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))     
+                    list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))         
     # create floor polygon
     for p_base_link in list_p_stamped_base_link:
         p_base_link.point.z = z_min

--- a/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
@@ -39,6 +39,7 @@ import ros2_numpy
 from rosidl_runtime_py import message_to_ordereddict
 from sensor_msgs.msg import PointCloud2
 from shapely.geometry import Polygon
+from shapely.geometry import MultiPolygon
 import simplejson as json
 from std_msgs.msg import ColorRGBA
 from std_msgs.msg import Header
@@ -386,13 +387,23 @@ def get_non_detection_area_in_base_link(
     )
     list_intersection_area = []
     list_p_stamped_base_link: list[PointStamped] = []
-    for i, shapely_point in enumerate(intersection_polygon.exterior.coords):
-        if i != len(intersection_polygon.exterior.coords) - 1:
-            p_stamped_map = PointStamped(
-                header=header,
-                point=Point(x=shapely_point[0], y=shapely_point[1], z=average_z),
-            )
-            list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))
+    if isinstance(intersection_polygon, Polygon):
+        for i, shapely_point in enumerate(intersection_polygon.exterior.coords):
+            if i != len(intersection_polygon.exterior.coords) - 1:
+                p_stamped_map = PointStamped(
+                    header=header,
+                    point=Point(x=shapely_point[0], y=shapely_point[1], z=average_z),
+                )
+                list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))
+    elif isinstance(intersection_polygon, MultiPolygon):
+        for poly in MultiPolygon.geoms:
+            for i, shapely_point in enumerate(poly.exterior.coords):
+                if i != len(intersection_polygon.exterior.coords) - 1:
+                    p_stamped_map = PointStamped(
+                        header=header,
+                        point=Point(x=shapely_point[0], y=shapely_point[1], z=average_z),
+                    )
+                    list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))
     # create floor polygon
     for p_base_link in list_p_stamped_base_link:
         p_base_link.point.z = z_min

--- a/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
@@ -387,20 +387,14 @@ def get_non_detection_area_in_base_link(
     )
     list_intersection_area = []
     list_p_stamped_base_link: list[PointStamped] = []
-    if isinstance(intersection_polygon, Polygon):
-        for i, shapely_point in enumerate(intersection_polygon.exterior.coords):
-            if i != len(intersection_polygon.exterior.coords) - 1:
-                p_stamped_map = PointStamped(
-                    header=header,
-                    point=Point(x=shapely_point[0], y=shapely_point[1], z=average_z),
-                )
-                list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))
+    polygons_to_process = []    
+    if isinstance(intersection_polygon, Polygon):  # Handle single Polygon
+        polygons_to_process.append(intersection_polygon)
     elif isinstance(intersection_polygon, MultiPolygon):
-        single_polygon_multipolygon = MultiPolygon([Polygon])
-        poly: Union[Polygon, MultiPolygon]
-        for poly in single_polygon_multipolygon.geoms:
-            for i, shapely_point in enumerate(poly.exterior.coords):
-                if i != len(intersection_polygon.exterior.coords) - 1:
+        polygons_to_process.extend(intersection_polygon.geoms) # Use .geoms to get a list of individual polygons from the MultiPolygon
+    for poly in polygons_to_process:
+        for i, shapely_point in enumerate(poly.exterior.coords):
+                if i != len(poly.exterior.coords) - 1:
                     p_stamped_map = PointStamped(
                         header=header,
                         point=Point(x=shapely_point[0], y=shapely_point[1], z=average_z),

--- a/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
@@ -387,19 +387,15 @@ def get_non_detection_area_in_base_link(
     )
     list_intersection_area = []
     list_p_stamped_base_link: list[PointStamped] = []
-    polygons_to_process = []    
-    if isinstance(intersection_polygon, Polygon):  # Handle single Polygon
-        polygons_to_process.append(intersection_polygon)
-    elif isinstance(intersection_polygon, MultiPolygon):
-        polygons_to_process.extend(intersection_polygon.geoms) # Use .geoms to get a list of individual polygons from the MultiPolygon
-    for poly in polygons_to_process:
-        for i, shapely_point in enumerate(poly.exterior.coords):
+    poly: Union[Polygon, MultiPolygon]
+    for poly in poly.geoms:
+            for i, shapely_point in enumerate(poly.exterior.coords):
                 if i != len(poly.exterior.coords) - 1:
                     p_stamped_map = PointStamped(
                         header=header,
                         point=Point(x=shapely_point[0], y=shapely_point[1], z=average_z),
                     )
-                    list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))
+                    list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))     
     # create floor polygon
     for p_base_link in list_p_stamped_base_link:
         p_base_link.point.z = z_min

--- a/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
@@ -396,7 +396,8 @@ def get_non_detection_area_in_base_link(
                 )
                 list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))
     elif isinstance(intersection_polygon, MultiPolygon):
-        for poly in MultiPolygon.geoms:
+        single_polygon_multipolygon = MultiPolygon([Polygon])
+        for poly in single_polygon_multipolygon.geoms:
             for i, shapely_point in enumerate(poly.exterior.coords):
                 if i != len(intersection_polygon.exterior.coords) - 1:
                     p_stamped_map = PointStamped(

--- a/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
@@ -38,8 +38,8 @@ from pydantic import field_validator
 import ros2_numpy
 from rosidl_runtime_py import message_to_ordereddict
 from sensor_msgs.msg import PointCloud2
-from shapely.geometry import Polygon
-from shapely.geometry import MultiPolygon
+from shapely.geometry import Polygon, MultiPolygon
+from typing import Union
 import simplejson as json
 from std_msgs.msg import ColorRGBA
 from std_msgs.msg import Header
@@ -397,6 +397,7 @@ def get_non_detection_area_in_base_link(
                 list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))
     elif isinstance(intersection_polygon, MultiPolygon):
         single_polygon_multipolygon = MultiPolygon([Polygon])
+        poly: Union[Polygon, MultiPolygon]
         for poly in single_polygon_multipolygon.geoms:
             for i, shapely_point in enumerate(poly.exterior.coords):
                 if i != len(intersection_polygon.exterior.coords) - 1:

--- a/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
@@ -387,15 +387,23 @@ def get_non_detection_area_in_base_link(
     )
     list_intersection_area = []
     list_p_stamped_base_link: list[PointStamped] = []
-    poly: Union[Polygon, MultiPolygon]
-    for poly in poly.geoms:
-        for i, shapely_point in enumerate(poly.exterior.coords):
-                if i != len(poly.exterior.coords) - 1:
+    if isinstance(intersection_polygon, Polygon):
+        for i, shapely_point in enumerate(intersection_polygon.exterior.coords):
+            if i != len(intersection_polygon.exterior.coords) - 1:
+                p_stamped_map = PointStamped(
+                    header=header,
+                    point=Point(x=shapely_point[0], y=shapely_point[1], z=average_z),
+                )
+                list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))
+    elif isinstance(intersection_polygon, MultiPolygon):
+        for poly in intersection_polygon.geoms:
+            for i, shapely_point in enumerate(poly.exterior.coords):
+                 if i != len(poly.exterior.coords) - 1:
                     p_stamped_map = PointStamped(
                         header=header,
                         point=Point(x=shapely_point[0], y=shapely_point[1], z=average_z),
                     )
-                    list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))         
+                    list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))
     # create floor polygon
     for p_base_link in list_p_stamped_base_link:
         p_base_link.point.z = z_min


### PR DESCRIPTION
## Types of PR
- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix　-- [Correction at shaply Polygon/Multipolygon to get non_detection_area in_base_link]

## Description
全拠点におけるObstacle Segmentation評価作業について

■課題 :　
polygonの定義「MultiPolygon(intersection_polygon.exterior.coords)のエラー」や「shapely.errors.TopologicalError:のエラー」が発生した。

■原因 :　
obstacle_segmentation_evaluator_node.pyに(intersection_polygon)のinstanceがPolygonだとexterior LinearRingのCoordinateでShape出来ますが、instanceがMultiPolygon だと「geoms」attributeを利用しないとexterior LinearRingのCoordinateでShape出来ないのが問題になります。
<img width="1149" height="651" alt="image" src="https://github.com/user-attachments/assets/64303e92-74f6-4491-8ae9-179ba35c06a2" />


<img width="989" height="311" alt="image" src="https://github.com/user-attachments/assets/d756b262-bdab-434b-9cd6-ae9aa1db2cd8" />

https://tier4.atlassian.net/wiki/spaces/~712020816beb62947449b89f90b77cc15ed4f9/pages/4242014445/Polygon+MultiPolygon


■解決方法 :
- obstacle_segmentation_evaluator_node.pyやobstacle_segmentation.pyのget_non_detection_area_in_base_linkに
（intersection_polygon）に関するinstanceを[Polygon, MultiPolygon]　分けて「geoms」attributeを利用してSourceCodeを修正しました。

- driving_log_replayerやpilot-auto.x1のブランチで「fixobstacle_segmentation_multipolygon」ブランチ作成、機能切り替え、Evaluatorで動作確認しています。


## How to review this PR
PR testはまだです。

## Others
p2d[3], p2d[0], p2d[1], p2d[2]で設定のOrder Sequence更新した。
https://tier4.atlassian.net/wiki/spaces/~712020816beb62947449b89f90b77cc15ed4f9/pages/3899883626

https://github.com/tier4/driving_log_replayer_v2/compare/exp/obstacle_segmentation_multipolygon
https://github.com/tier4/pilot-auto.x1/compare/beta/v2025.8...fix/obstacle_segmentation_multipolygon

以下のSlackリンクにより作業いたしました。
https://tier4.atlassian.net/wiki/spaces/~712020816beb62947449b89f90b77cc15ed4f9/pages/3869147329/obstacle_segmentation

