### PR TITLE
fix(topic remapping): a bug of remapping regarding goal_pose

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/rosbag.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/rosbag.py
@@ -61,7 +61,7 @@ def system_defined_remap(conf: dict) -> list[str]:
         add_remap("/tf", remap_list)
         add_remap("/localization/kinematic_state", remap_list)
         add_remap("/localization/acceleration", remap_list)
-    if conf.get("goal_pose") is not None and conf["goal_pose"] != "{}":
+    if conf.get("goal_pose", "{}") != "{}":
         add_remap("/planning/mission_planning/route", remap_list)
     return remap_list
 

--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/rosbag.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/rosbag.py
@@ -61,7 +61,7 @@ def system_defined_remap(conf: dict) -> list[str]:
         add_remap("/tf", remap_list)
         add_remap("/localization/kinematic_state", remap_list)
         add_remap("/localization/acceleration", remap_list)
-    if conf.get("goal_pose") is not None:
+    if conf.get("goal_pose") is not None and conf["goal_pose"] != "{}":
         add_remap("/planning/mission_planning/route", remap_list)
     return remap_list
 


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Description
The original remapping doesn't work as expected because the `conf[goal_pose]` may not be None but a string `{}` in `planning_control` or `localization` scenarios
This PR fixes this problem.

## How to review this PR

## Others
