### PR TITLE
feat(perception): update test caused by adding the `nuscene_object_results` in perception_eval

### DIFF
--- a/dependency.repos
+++ b/dependency.repos
@@ -22,7 +22,7 @@ repositories:
   autoware/autoware_lanelet2_extension:
     type: git
     url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-    version: 0.6.2
+    version: 0.7.0
   autoware/tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git

--- a/driving_log_replayer_v2/test/unittest/test_perception.py
+++ b/driving_log_replayer_v2/test/unittest/test_perception.py
@@ -85,6 +85,8 @@ def create_frame_result() -> PerceptionFrameResult:
     evaluation_config_dict = scenario.Evaluation.PerceptionEvaluationConfig[
         "evaluation_config_dict"
     ]
+    critical_object_filter_config = scenario.Evaluation.CriticalObjectFilterConfig
+    perception_pass_fail_config = scenario.Evaluation.PerceptionPassFailConfig
     evaluation_config_dict["label_prefix"] = "autoware"
     m_params: dict = {
         "target_labels": evaluation_config_dict["target_labels"],
@@ -111,13 +113,14 @@ def create_frame_result() -> PerceptionFrameResult:
         ),
         critical_object_filter_config=CriticalObjectFilterConfig(
             evaluation_config,
-            evaluation_config_dict["target_labels"],
-            max_x_position_list=[30.0, 30.0, 30.0, 30.0, 30.0],
-            max_y_position_list=[30.0, 30.0, 30.0, 30.0, 30.0],
+            critical_object_filter_config["target_labels"],
+            max_x_position_list=critical_object_filter_config["max_x_position_list"],
+            max_y_position_list=critical_object_filter_config["max_y_position_list"],
         ),
         frame_pass_fail_config=PerceptionPassFailConfig(
             evaluation_config,
-            evaluation_config_dict["target_labels"],
+            perception_pass_fail_config["target_labels"],
+            matching_threshold_list=perception_pass_fail_config["matching_threshold_list"],
         ),
         unix_time=123,
         target_labels=[AutowareLabel.CAR],

--- a/driving_log_replayer_v2/test/unittest/test_perception.py
+++ b/driving_log_replayer_v2/test/unittest/test_perception.py
@@ -102,7 +102,8 @@ def create_frame_result() -> PerceptionFrameResult:
     )
 
     return PerceptionFrameResult(
-        object_results=[],
+        object_results=None,
+        nuscene_object_results=[],
         frame_ground_truth=FrameGroundTruth(123, "12", []),
         metrics_config=MetricsScoreConfig(
             EvaluationTask.DETECTION,

--- a/driving_log_replayer_v2/test/unittest/test_perception_2d.py
+++ b/driving_log_replayer_v2/test/unittest/test_perception_2d.py
@@ -67,6 +67,7 @@ def create_frame_result() -> PerceptionFrameResult:
 
     return PerceptionFrameResult(
         object_results=[],
+        nuscene_object_results=None,
         frame_ground_truth=FrameGroundTruth(123, "12", []),
         metrics_config=MetricsScoreConfig(
             EvaluationTask.DETECTION2D,

--- a/driving_log_replayer_v2/test/unittest/test_perception_2d.py
+++ b/driving_log_replayer_v2/test/unittest/test_perception_2d.py
@@ -77,7 +77,9 @@ def create_frame_result() -> PerceptionFrameResult:
             evaluation_config,
             target_labels,
         ),
-        frame_pass_fail_config=PerceptionPassFailConfig(evaluation_config, target_labels),
+        frame_pass_fail_config=PerceptionPassFailConfig(
+            evaluation_config, target_labels, matching_threshold_list=[2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
+        ),
         unix_time=123,
         target_labels=[AutowareLabel.CAR],
     )

--- a/driving_log_replayer_v2/test/unittest/test_traffic_light.py
+++ b/driving_log_replayer_v2/test/unittest/test_traffic_light.py
@@ -71,6 +71,7 @@ def create_frame_result() -> PerceptionFrameResult:
 
     return PerceptionFrameResult(
         object_results=[],
+        nuscene_object_results=None,
         frame_ground_truth=FrameGroundTruth(123, "12", []),
         metrics_config=MetricsScoreConfig(
             EvaluationTask.CLASSIFICATION2D,

--- a/repository.cspell.json
+++ b/repository.cspell.json
@@ -23,6 +23,7 @@
     "MOTA",
     "MOTP",
     "nums",
+    "nuscene",
     "nuscenes",
     "objdata",
     "pydantic",


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [x] Upgrade of existing features
- [ ] Bugfix

## Description

This PR adds the `nuscene_object_results` in test code.


## How to review this PR

## Others
