### PR TITLE
feat(localization): make conditions detachable

### DIFF
--- a/driving_log_replayer_v2/scripts/localization_evaluator_node.py
+++ b/driving_log_replayer_v2/scripts/localization_evaluator_node.py
@@ -37,7 +37,11 @@ class LocalizationEvaluator(DLREvaluatorV2):
         self._scenario: LocalizationScenario
         self._result: LocalizationResult
 
-        self.__reliability_method = self._scenario.Evaluation.Conditions.Reliability.Method
+        self.__reliability_method = (
+            self._scenario.Evaluation.Conditions.Reliability.Method
+            if self._scenario.Evaluation.Conditions.Reliability
+            else "NVTL"
+        )
 
         self.__latest_exe_time: Float32Stamped = Float32Stamped()
         self.__latest_iteration_num: Int32Stamped = Int32Stamped()

--- a/driving_log_replayer_v2/scripts/localization_evaluator_node.py
+++ b/driving_log_replayer_v2/scripts/localization_evaluator_node.py
@@ -105,7 +105,7 @@ class LocalizationEvaluator(DLREvaluatorV2):
         self._result.set_frame(
             msg,
             DLREvaluatorV2.transform_stamped_with_euler_angle(map_to_baselink),
-            self.__latest_nvtl,
+            self.__latest_tp,
         )
         self._result_writer.write_result(self._result)
 
@@ -118,7 +118,7 @@ class LocalizationEvaluator(DLREvaluatorV2):
         self._result.set_frame(
             msg,
             DLREvaluatorV2.transform_stamped_with_euler_angle(map_to_baselink),
-            self.__latest_tp,
+            self.__latest_nvtl,
         )
         self._result_writer.write_result(self._result)
 


### PR DESCRIPTION
## Types of PR

- [x] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Description

Currently, `localization` type scenarios must have `Convergence` and `Reliability` Conditions to run evaluation.
Plus, the success/failure of the evaluation is always an AND condition of these two.

However, there will be scenarios that these conditions shouldn't be used.
Hence, this PR makes the localization scenario so that `Convergence` and `Reliability` conditions can be detachable.
You can remove the `Convergence` or `Reliability` block if you don't want to use them.

## How to review this PR

## Others

**Note that...**
- The `Availability` test still remains.
- No conditions will make the evaluator fail. You have to set at least one condition.

**and ...**
- I've just found a bug that the evaluator is using the TP and NVTL the opposite, so I've also fixed that part.