### PR TITLE
fix: update srv type for InitializeLocalization

### DIFF
--- a/driving_log_replayer_v2/package.xml
+++ b/driving_log_replayer_v2/package.xml
@@ -20,6 +20,7 @@
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_localization_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
+  <depend>autoware_localization_msgs</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>diagnostic_msgs</depend>

--- a/driving_log_replayer_v2/scripts/initial_pose_node.py
+++ b/driving_log_replayer_v2/scripts/initial_pose_node.py
@@ -16,10 +16,10 @@
 
 from typing import TYPE_CHECKING
 
-from autoware_internal_localization_msgs.srv import InitializeLocalization
 from autoware_internal_localization_msgs.srv import (
     PoseWithCovarianceStamped as PoseWithCovarianceStampedSrv,
 )
+from autoware_localization_msgs.srv import InitializeLocalization
 import rclpy
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.clock import Clock


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Description

This PR fixes the srv type of InitializeLocalization so that the `initial_pose_node` will work when the InitialPose or DirectInitialPose is given

Actually it was dead for about three months.
https://github.com/autowarefoundation/autoware_core/pull/542

## How to review this PR
It seems it doesn't affect the evaluator results.
https://evaluation.tier4.jp/evaluation/reports/0def149c-b7b6-5ce1-9809-552fcb230533?project_id=autoware_dev

## Others
