### PR TITLE
feat: publish conditions and results to topics

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/evaluator.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/evaluator.py
@@ -49,7 +49,7 @@ class DLREvaluatorV2(Node):
         name: str,
         scenario_class: Callable,
         result_class: Callable,
-        result_topic: None | str = "/driving_log_replayer/results",
+        result_topic: None | str = None,
     ) -> None:
         super().__init__(name)
         self.declare_parameter("scenario_path", "")
@@ -95,7 +95,12 @@ class DLREvaluatorV2(Node):
                 evaluation_condition,
             )
             self._result = result_class(evaluation_condition)
-        except (FileNotFoundError, PermissionError, yaml.YAMLError, ValidationError) as e:
+        except (
+            FileNotFoundError,
+            PermissionError,
+            yaml.YAMLError,
+            ValidationError,
+        ) as e:
             self.get_logger().error(f"An error occurred while loading the scenario. {e}")
             self._result_writer = ResultWriter(
                 self._result_json_path,
@@ -166,7 +171,10 @@ class DLREvaluatorV2(Node):
             return TransformStamped()
 
     def save_pkl(self, save_object: Any) -> None:
-        PickleWriter(self._result_archive_path.joinpath("scene_result.pkl").as_posix(), save_object)
+        PickleWriter(
+            self._result_archive_path.joinpath("scene_result.pkl").as_posix(),
+            save_object,
+        )
 
     @classmethod
     def transform_stamped_with_euler_angle(cls, transform_stamped: TransformStamped) -> dict:

--- a/driving_log_replayer_v2/driving_log_replayer_v2/evaluator.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/evaluator.py
@@ -92,7 +92,7 @@ class DLREvaluatorV2(Node):
                 and self._scenario.Evaluation.Conditions is not None
             ):
                 evaluation_condition = self._scenario.Evaluation.Conditions
-                if result_topic is not None:
+                if condition_topic is not None:
                     self._pub_condition = self.create_publisher(
                         String,
                         condition_topic,

--- a/driving_log_replayer_v2/driving_log_replayer_v2/evaluator.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/evaluator.py
@@ -27,9 +27,14 @@ from rclpy.clock import Clock
 from rclpy.clock import ClockType
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
+from rclpy.qos import QoSDurabilityPolicy
+from rclpy.qos import QoSHistoryPolicy
+from rclpy.qos import QoSProfile
+from rclpy.qos import QoSReliabilityPolicy
 from rclpy.time import Duration
 from rclpy.time import Time
 from rosidl_runtime_py import message_to_ordereddict
+from std_msgs.msg import String
 from tf2_ros import Buffer
 from tf2_ros import TransformException
 from tf2_ros import TransformListener
@@ -43,7 +48,14 @@ from driving_log_replayer_v2.scenario import load_scenario
 class DLREvaluatorV2(Node):
     COUNT_SHUTDOWN_NODE = 5
 
-    def __init__(self, name: str, scenario_class: Callable, result_class: Callable) -> None:
+    def __init__(
+        self,
+        name: str,
+        scenario_class: Callable,
+        result_class: Callable,
+        result_topic: None | str = "/driving_log_replayer/results",
+        condition_topic: None | str = "/driving_log_replayer/conditions",
+    ) -> None:
         super().__init__(name)
         self.declare_parameter("scenario_path", "")
         self.declare_parameter("t4_dataset_path", "")
@@ -73,15 +85,33 @@ class DLREvaluatorV2(Node):
         try:
             self._scenario = load_scenario(Path(self._scenario_path), scenario_class)
             evaluation_condition = {}
+            self._pub_condition = None
+            self._pub_result = None
             if (
                 hasattr(self._scenario.Evaluation, "Conditions")
                 and self._scenario.Evaluation.Conditions is not None
             ):
                 evaluation_condition = self._scenario.Evaluation.Conditions
+                if result_topic is not None:
+                    self._pub_condition = self.create_publisher(
+                        String,
+                        condition_topic,
+                        QoSProfile(
+                            history=QoSHistoryPolicy.KEEP_LAST,
+                            depth=1,
+                            reliability=QoSReliabilityPolicy.RELIABLE,
+                            durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+                        ),
+                    )
+                if result_topic is not None:
+                    self._pub_result = self.create_publisher(String, result_topic, 1)
+
             self._result_writer = ResultWriter(
                 self._result_json_path,
                 self.get_clock(),
                 evaluation_condition,
+                self._pub_result,
+                self._pub_condition,
             )
             self._result = result_class(evaluation_condition)
         except (FileNotFoundError, PermissionError, yaml.YAMLError, ValidationError) as e:

--- a/driving_log_replayer_v2/driving_log_replayer_v2/evaluator.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/evaluator.py
@@ -49,7 +49,7 @@ class DLREvaluatorV2(Node):
         name: str,
         scenario_class: Callable,
         result_class: Callable,
-        result_topic: None | str = None,
+        result_topic: str,
     ) -> None:
         super().__init__(name)
         self.declare_parameter("scenario_path", "")
@@ -80,14 +80,11 @@ class DLREvaluatorV2(Node):
         try:
             self._scenario = load_scenario(Path(self._scenario_path), scenario_class)
             evaluation_condition = {}
-            self._pub_result = None
             if (
                 hasattr(self._scenario.Evaluation, "Conditions")
                 and self._scenario.Evaluation.Conditions is not None
             ):
                 evaluation_condition = self._scenario.Evaluation.Conditions
-                if result_topic is not None:
-                    self._pub_result = self.create_publisher(String, result_topic, 1)
 
             self._result_writer = ResultWriter(
                 self._result_json_path,
@@ -95,6 +92,7 @@ class DLREvaluatorV2(Node):
                 evaluation_condition,
             )
             self._result = result_class(evaluation_condition)
+            self._pub_result = self.create_publisher(String, result_topic, 1)
         except (
             FileNotFoundError,
             PermissionError,

--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/planning_control.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/planning_control.py
@@ -16,8 +16,18 @@ from launch.actions import DeclareLaunchArgument
 
 RECORD_TOPIC = """^/tf$\
 |^/diagnostics$\
-|^/control/control_evaluator/metrics$\
-|^/planning/planning_evaluator/metrics$\
+|^/map/vector_map_marker$\
+|^/perception/object_recognition/objects$\
+|^/perception/object_recognition/detection/objects$\
+|^/perception/object_recognition/tracking/objects$\
+|^/perception/traffic_light_recognition/traffic_signals$\
+|^/perception/occupancy_grid_map/map$\
+|^/perception/obstacle_segmentation/pointcloud$\
+|^/localization/kinematic_state$\
+|^/localization/acceleration$\
+|^/planning/.*$\
+|^/control/.*$\
+|^/driving_log_replayer/.*\
 """
 
 AUTOWARE_DISABLE = {

--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/planning_control.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/planning_control.py
@@ -19,6 +19,7 @@ RECORD_TOPIC = """^/tf$\
 |^/parameter_events$\
 |^/diagnostics$\
 |^/map/vector_map_marker$\
+|^/map/pointcloud_map$\
 |^/perception/object_recognition/objects$\
 |^/perception/object_recognition/detection/objects$\
 |^/perception/object_recognition/tracking/objects$\

--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/planning_control.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/planning_control.py
@@ -15,6 +15,8 @@
 from launch.actions import DeclareLaunchArgument
 
 RECORD_TOPIC = """^/tf$\
+|^/tf_static$\
+|^/parameter_events$\
 |^/diagnostics$\
 |^/map/vector_map_marker$\
 |^/perception/object_recognition/objects$\
@@ -23,10 +25,14 @@ RECORD_TOPIC = """^/tf$\
 |^/perception/traffic_light_recognition/traffic_signals$\
 |^/perception/occupancy_grid_map/map$\
 |^/perception/obstacle_segmentation/pointcloud$\
+|^/system/v2x/virtual_traffic_light_states$\
 |^/localization/kinematic_state$\
+|^/localization/initialization_state$\
+|^/localization/pose_with_covariance$\
 |^/localization/acceleration$\
 |^/planning/.*$\
 |^/control/.*$\
+|^/system/processing_time_checker/metrics$\
 |^/driving_log_replayer/.*\
 """
 

--- a/driving_log_replayer_v2/driving_log_replayer_v2/result.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/result.py
@@ -24,7 +24,9 @@ from ament_index_python.packages import get_package_share_directory
 from pydantic import BaseModel
 from rclpy.clock import Clock
 from rclpy.clock import ClockType
+from rclpy.publisher import Publisher
 import simplejson as json
+from std_msgs.msg import String
 
 
 def get_sample_result_path(
@@ -95,7 +97,11 @@ class ResultWriter:
         result_json_path: str,
         ros_clock: Clock,
         condition: BaseModel | dict,
+        result_publisher: Publisher | None = None,
+        condition_publisher: Publisher | None = None,
     ) -> None:
+        self.result_publisher = result_publisher
+        self.condition_publisher = condition_publisher
         self._result_path = self.create_jsonl_path(result_json_path)
         self._result_file = self._result_path.open("w")
         self._ros_clock = ros_clock
@@ -120,15 +126,17 @@ class ResultWriter:
     def delete_result_file(self) -> None:
         self._result_path.unlink()
 
-    def write_line(self, write_obj: Any) -> None:
-        str_record = json.dumps(write_obj, ignore_nan=True) + "\n"
-        self._result_file.write(str_record)
+    def write_line(self, write_obj: Any, str_publisher: Publisher | None = None) -> None:
+        str_record = json.dumps(write_obj, ignore_nan=True)
+        self._result_file.write(str_record + "\n")
+        if str_publisher is not None:
+            str_publisher.publish(String(data=str_record))
 
     def write_result(self, result: ResultBase) -> None:
-        self.write_line(self.get_result(result, None))
+        self.write_line(self.get_result(result, None), self.result_publisher)
 
     def write_result_with_time(self, result: ResultBase, ros_timestamp: int) -> None:
-        self.write_line(self.get_result(result, ros_timestamp))
+        self.write_line(self.get_result(result, ros_timestamp), self.result_publisher)
 
     def write_condition(self, condition: BaseModel | dict | list, *, updated: bool = False) -> None:
         if isinstance(condition, list):
@@ -144,7 +152,7 @@ class ResultWriter:
         if updated:
             key = "UpdatedCondition"
         write_obj = {key: condition_dict}
-        self.write_line(write_obj)
+        self.write_line(write_obj, self.condition_publisher)
 
     def get_header(self) -> dict:
         system_time = self._system_clock.now()

--- a/driving_log_replayer_v2/scripts/annotationless_perception_evaluator_node.py
+++ b/driving_log_replayer_v2/scripts/annotationless_perception_evaluator_node.py
@@ -16,6 +16,7 @@
 
 
 from diagnostic_msgs.msg import DiagnosticArray
+from std_msgs.msg import String
 
 from driving_log_replayer_v2.annotationless_perception import AnnotationlessPerceptionResult
 from driving_log_replayer_v2.annotationless_perception import AnnotationlessPerceptionScenario
@@ -25,7 +26,12 @@ from driving_log_replayer_v2.evaluator import evaluator_main
 
 class AnnotationlessPerceptionEvaluator(DLREvaluatorV2):
     def __init__(self, name: str) -> None:
-        super().__init__(name, AnnotationlessPerceptionScenario, AnnotationlessPerceptionResult)
+        super().__init__(
+            name,
+            AnnotationlessPerceptionScenario,
+            AnnotationlessPerceptionResult,
+            "/driving_log_replayer/annotationless_perception/results",
+        )
         self._scenario: AnnotationlessPerceptionScenario
         self._result: AnnotationlessPerceptionResult
 
@@ -38,14 +44,16 @@ class AnnotationlessPerceptionEvaluator(DLREvaluatorV2):
 
     def diagnostics_cb(self, msg: DiagnosticArray) -> None:
         self._result.set_frame(msg)
-        self._result_writer.write_result(self._result)
+        res_str = self._result_writer.write_result(self._result)
+        self._pub_result.publish(String(data=res_str))
 
     def timer_cb(self) -> None:
         super().timer_cb(register_shutdown_func=self.write_metrics)
 
     def write_metrics(self) -> None:
         self._result.set_final_metrics()
-        self._result_writer.write_result(self._result)
+        res_str = self._result_writer.write_result(self._result)
+        self._pub_result.publish(String(data=res_str))
 
 
 @evaluator_main

--- a/driving_log_replayer_v2/scripts/ar_tag_based_localizer_evaluator_node.py
+++ b/driving_log_replayer_v2/scripts/ar_tag_based_localizer_evaluator_node.py
@@ -16,6 +16,7 @@
 
 from diagnostic_msgs.msg import DiagnosticArray
 from diagnostic_msgs.msg import DiagnosticStatus
+from std_msgs.msg import String
 
 from driving_log_replayer_v2.ar_tag_based_localizer import ArTagBasedLocalizerResult
 from driving_log_replayer_v2.ar_tag_based_localizer import ArtagBasedLocalizerScenario
@@ -27,7 +28,12 @@ TARGET_DIAG_NAME = "localization: ar_tag_based_localizer"
 
 class ArTagBasedLocalizerEvaluator(DLREvaluatorV2):
     def __init__(self, name: str) -> None:
-        super().__init__(name, ArtagBasedLocalizerScenario, ArTagBasedLocalizerResult)
+        super().__init__(
+            name,
+            ArtagBasedLocalizerScenario,
+            ArTagBasedLocalizerResult,
+            "/driving_log_replayer/ar_tag_based_localizer/results",
+        )
         self._result: ArTagBasedLocalizerResult
 
         self.__sub_diagnostics = self.create_subscription(
@@ -44,7 +50,8 @@ class ArTagBasedLocalizerEvaluator(DLREvaluatorV2):
         if diag_status.name != TARGET_DIAG_NAME:
             return
         self._result.set_frame(diag_status)
-        self._result_writer.write_result(self._result)
+        res_str = self._result_writer.write_result(self._result)
+        self._pub_result.publish(String(data=res_str))
 
 
 @evaluator_main

--- a/driving_log_replayer_v2/scripts/diagnostics_evaluator_node.py
+++ b/driving_log_replayer_v2/scripts/diagnostics_evaluator_node.py
@@ -19,6 +19,7 @@ from collections.abc import Callable
 
 from diagnostic_msgs.msg import DiagnosticArray
 from diagnostic_msgs.msg import DiagnosticStatus
+from std_msgs.msg import String
 
 from driving_log_replayer_v2.diagnostics import DiagnosticsResult
 from driving_log_replayer_v2.diagnostics import DiagnosticsScenario
@@ -33,7 +34,9 @@ class DiagnosticsEvaluator(DLREvaluatorV2):
         scenario_class: Callable = DiagnosticsScenario,
         result_class: Callable = DiagnosticsResult,
     ) -> None:
-        super().__init__(name, scenario_class, result_class)
+        super().__init__(
+            name, scenario_class, result_class, "/driving_log_replayer/diagnostics_results"
+        )
         self._scenario: DiagnosticsScenario
         self._result: DiagnosticsResult
 
@@ -52,7 +55,8 @@ class DiagnosticsEvaluator(DLREvaluatorV2):
             return
         self._result.set_frame(msg)
         if self._result.frame != {}:
-            self._result_writer.write_result(self._result)
+            res_str = self._result_writer.write_result(self._result)
+            self._pub_result.publish(String(data=res_str))
 
 
 @evaluator_main

--- a/driving_log_replayer_v2/scripts/diagnostics_evaluator_node.py
+++ b/driving_log_replayer_v2/scripts/diagnostics_evaluator_node.py
@@ -35,7 +35,7 @@ class DiagnosticsEvaluator(DLREvaluatorV2):
         result_class: Callable = DiagnosticsResult,
     ) -> None:
         super().__init__(
-            name, scenario_class, result_class, "/driving_log_replayer/diagnostics_results"
+            name, scenario_class, result_class, "/driving_log_replayer/diagnostics/results"
         )
         self._scenario: DiagnosticsScenario
         self._result: DiagnosticsResult

--- a/driving_log_replayer_v2/scripts/eagleye_evaluator_node.py
+++ b/driving_log_replayer_v2/scripts/eagleye_evaluator_node.py
@@ -16,6 +16,7 @@
 
 from diagnostic_msgs.msg import DiagnosticArray
 from diagnostic_msgs.msg import DiagnosticStatus
+from std_msgs.msg import String
 
 from driving_log_replayer_v2.eagleye import EagleyeResult
 from driving_log_replayer_v2.eagleye import EagleyeScenario
@@ -27,7 +28,9 @@ TARGET_DIAG_NAME = "monitor: eagleye_enu_absolute_pos_interpolate"
 
 class EagleyeEvaluator(DLREvaluatorV2):
     def __init__(self, name: str) -> None:
-        super().__init__(name, EagleyeScenario, EagleyeResult)
+        super().__init__(
+            name, EagleyeScenario, EagleyeResult, "/driving_log_replayer/eagleye/results"
+        )
         self._result: EagleyeResult
 
         self.__sub_diagnostics = self.create_subscription(
@@ -43,7 +46,8 @@ class EagleyeEvaluator(DLREvaluatorV2):
             diag_status: DiagnosticStatus
             if diag_status.name == TARGET_DIAG_NAME:
                 self._result.set_frame(diag_status)
-                self._result_writer.write_result(self._result)
+                res_str = self._result_writer.write_result(self._result)
+                self._pub_result.publish(String(data=res_str))
 
 
 @evaluator_main

--- a/driving_log_replayer_v2/scripts/ground_segmentation_evaluator_node.py
+++ b/driving_log_replayer_v2/scripts/ground_segmentation_evaluator_node.py
@@ -22,6 +22,7 @@ from rclpy.qos import qos_profile_sensor_data
 import ros2_numpy
 from scipy.spatial import cKDTree
 from sensor_msgs.msg import PointCloud2
+from std_msgs.msg import String
 
 from driving_log_replayer_v2.evaluator import DLREvaluatorV2
 from driving_log_replayer_v2.evaluator import evaluator_main
@@ -37,7 +38,12 @@ class GroundSegmentationEvaluator(DLREvaluatorV2):
     TS_DIFF_THRESH = 75000
 
     def __init__(self, name: str) -> None:
-        super().__init__(name, GroundSegmentationScenario, GroundSegmentationResult)
+        super().__init__(
+            name,
+            GroundSegmentationScenario,
+            GroundSegmentationResult,
+            "/driving_log_replayer/ground_segmentation/results",
+        )
 
         eval_condition: Condition = self._scenario.Evaluation.Conditions
         self.ground_label = eval_condition.ground_label
@@ -155,7 +161,8 @@ class GroundSegmentationEvaluator(DLREvaluatorV2):
         frame_result.f1_score = metrics_list[4]
 
         self._result.set_frame(frame_result)
-        self._result_writer.write_result(self._result)
+        res_str = self._result_writer.write_result(self._result)
+        self._pub_result.publish(String(data=res_str))
 
     def __get_gt_frame_ts(self, unix_time: int) -> int:
         ts_itr = iter(self.ground_truth.keys())

--- a/driving_log_replayer_v2/scripts/obstacle_segmentation_evaluator_node.py
+++ b/driving_log_replayer_v2/scripts/obstacle_segmentation_evaluator_node.py
@@ -37,6 +37,7 @@ from rosidl_runtime_py import message_to_ordereddict
 from sensor_msgs.msg import PointCloud2
 import simplejson as json
 from std_msgs.msg import Header
+from std_msgs.msg import String
 from tier4_api_msgs.msg import AwapiAutowareStatus
 from visualization_msgs.msg import MarkerArray
 
@@ -69,7 +70,12 @@ class ObstacleSegmentationEvaluator(DLREvaluatorV2):
     COUNT_FINISH_PUB_GOAL_POSE = 5
 
     def __init__(self, name: str) -> None:
-        super().__init__(name, ObstacleSegmentationScenario, ObstacleSegmentationResult)
+        super().__init__(
+            name,
+            ObstacleSegmentationScenario,
+            ObstacleSegmentationResult,
+            "/driving_log_replayer/obstacle_segmentation/results",
+        )
         self._result: ObstacleSegmentationResult
 
         # pub_goal_pose must be created before timer_cb is called
@@ -275,7 +281,8 @@ class ObstacleSegmentationEvaluator(DLREvaluatorV2):
             pcd_header,
             topic_rate=self.__topic_rate,
         )
-        self._result_writer.write_result(self._result)
+        res_str = self._result_writer.write_result(self._result)
+        self._pub_result.publish(String(data=res_str))
 
         topic_rate_data = ObstacleSegmentationMarker()
         topic_rate_data.header = msg.header

--- a/driving_log_replayer_v2/scripts/perception_2d_evaluator_node.py
+++ b/driving_log_replayer_v2/scripts/perception_2d_evaluator_node.py
@@ -27,6 +27,7 @@ from perception_eval.manager import PerceptionEvaluationManager
 from perception_eval.tool import PerceptionAnalyzer2D
 from perception_eval.util.logger_config import configure_logger
 import rclpy
+from std_msgs.msg import String
 from tier4_perception_msgs.msg import DetectedObjectsWithFeature
 from tier4_perception_msgs.msg import DetectedObjectWithFeature
 
@@ -42,7 +43,12 @@ if TYPE_CHECKING:
 
 class Perception2DEvaluator(DLREvaluatorV2):
     def __init__(self, name: str) -> None:
-        super().__init__(name, Perception2DScenario, Perception2DResult)
+        super().__init__(
+            name,
+            Perception2DScenario,
+            Perception2DResult,
+            "/driving_log_replayer/perception_2d/results",
+        )
         self._scenario: Perception2DScenario
         self._result: Perception2DResult
 
@@ -183,7 +189,8 @@ class Perception2DEvaluator(DLREvaluatorV2):
                 DLREvaluatorV2.transform_stamped_with_euler_angle(map_to_baselink),
                 camera_type,
             )
-            self._result_writer.write_result(self._result)
+            res_str = self._result_writer.write_result(self._result)
+            self._pub_result.publish(String(data=res_str))
 
     def get_final_result(self) -> MetricsScore:
         final_metric_score = self.__evaluator.get_scene_result()

--- a/driving_log_replayer_v2/scripts/performance_diag_evaluator_node.py
+++ b/driving_log_replayer_v2/scripts/performance_diag_evaluator_node.py
@@ -21,6 +21,7 @@ from diagnostic_msgs.msg import DiagnosticArray
 from diagnostic_msgs.msg import DiagnosticStatus
 from example_interfaces.msg import Byte
 from example_interfaces.msg import Float64
+from std_msgs.msg import String
 
 from driving_log_replayer_v2.evaluator import DLREvaluatorV2
 from driving_log_replayer_v2.evaluator import evaluator_main
@@ -38,7 +39,12 @@ def extract_lidar_name(diag_name: str) -> str:
 
 class PerformanceDiagEvaluator(DLREvaluatorV2):
     def __init__(self, name: str) -> None:
-        super().__init__(name, PerformanceDiagScenario, PerformanceDiagResult)
+        super().__init__(
+            name,
+            PerformanceDiagScenario,
+            PerformanceDiagResult,
+            "/driving_log_replayer/performance_diag/results",
+        )
         self._scenario: PerformanceDiagScenario
         self._result: PerformanceDiagResult
 
@@ -109,7 +115,8 @@ class PerformanceDiagEvaluator(DLREvaluatorV2):
                 self.__pub_blockage_ground_ratios[lidar_name].publish(msg_blockage_ground_ratio)
             if msg_blockage_level is not None:
                 self.__pub_blockage_levels[lidar_name].publish(msg_blockage_level)
-        self._result_writer.write_result(self._result)
+        res_str = self._result_writer.write_result(self._result)
+        self._pub_result.publish(String(data=res_str))
 
 
 @evaluator_main

--- a/driving_log_replayer_v2/scripts/planning_control_evaluator_node.py
+++ b/driving_log_replayer_v2/scripts/planning_control_evaluator_node.py
@@ -39,7 +39,7 @@ class PlanningControlEvaluator(DLREvaluatorV2):
         result_class: Callable = MetricResult,
     ) -> None:
         super().__init__(
-            name, scenario_class, result_class, "/driving_log_replayer/metrics_results"
+            name, scenario_class, result_class, "/driving_log_replayer/planning_control/results"
         )
         self._scenario: PlanningControlScenario
         self._result: MetricResult
@@ -73,7 +73,7 @@ class PlanningControlEvaluator(DLREvaluatorV2):
         pf_conditions = self._scenario.Evaluation.Conditions.PlanningFactorConditions
         if pf_conditions != []:
             self._pub_pf_result = self.create_publisher(
-                String, "/driving_log_replayer/planning_factor_results", 1
+                String, "/driving_log_replayer/planning_factor/results", 1
             )
 
             self._planning_factor_result = PlanningFactorResult(pf_conditions)
@@ -96,7 +96,7 @@ class PlanningControlEvaluator(DLREvaluatorV2):
 
         if self._scenario.include_use_case is not None:
             self._pub_diag_result = self.create_publisher(
-                String, "/driving_log_replayer/diagnostics_results", 1
+                String, "/driving_log_replayer/diagnostics/results", 1
             )
 
             diag_conditions = self._scenario.include_use_case.Conditions

--- a/driving_log_replayer_v2/scripts/traffic_light_evaluator_node.py
+++ b/driving_log_replayer_v2/scripts/traffic_light_evaluator_node.py
@@ -39,6 +39,7 @@ from perception_eval.manager import PerceptionEvaluationManager
 from perception_eval.tool import PerceptionAnalyzer2D
 from perception_eval.util.logger_config import configure_logger
 import rclpy
+from std_msgs.msg import String
 
 from driving_log_replayer_v2.evaluator import DLREvaluatorV2
 from driving_log_replayer_v2.evaluator import evaluator_main
@@ -55,7 +56,12 @@ if TYPE_CHECKING:
 
 class TrafficLightEvaluator(DLREvaluatorV2):
     def __init__(self, name: str) -> None:
-        super().__init__(name, TrafficLightScenario, TrafficLightResult)
+        super().__init__(
+            name,
+            TrafficLightScenario,
+            TrafficLightResult,
+            "/driving_log_replayer/traffic_light/results",
+        )
         self._scenario: TrafficLightScenario
         self._result: TrafficLightResult
 
@@ -261,7 +267,8 @@ class TrafficLightEvaluator(DLREvaluatorV2):
             DLREvaluatorV2.transform_stamped_with_euler_angle(map_to_baselink),
         )
         self.fail_result_holder.add_frame(frame_result)
-        self._result_writer.write_result(self._result)
+        res_str = self._result_writer.write_result(self._result)
+        self._pub_result.publish(String(data=res_str))
 
     def get_final_result(self) -> MetricsScore:
         final_metric_score = self.__evaluator.get_scene_result()

--- a/driving_log_replayer_v2/scripts/yabloc_evaluator_node.py
+++ b/driving_log_replayer_v2/scripts/yabloc_evaluator_node.py
@@ -16,6 +16,7 @@
 
 
 from diagnostic_msgs.msg import DiagnosticArray
+from std_msgs.msg import String
 
 from driving_log_replayer_v2.evaluator import DLREvaluatorV2
 from driving_log_replayer_v2.evaluator import evaluator_main
@@ -27,7 +28,7 @@ TARGET_DIAG_NAME = "yabloc_monitor: yabloc_status"
 
 class YabLocEvaluator(DLREvaluatorV2):
     def __init__(self, name: str) -> None:
-        super().__init__(name, YablocScenario, YabLocResult)
+        super().__init__(name, YablocScenario, YabLocResult, "/driving_log_replayer/yabloc/results")
         self._result: YabLocResult
 
         self.__sub_diagnostics = self.create_subscription(
@@ -44,7 +45,8 @@ class YabLocEvaluator(DLREvaluatorV2):
         if diag_status.name != TARGET_DIAG_NAME:
             return
         self._result.set_frame(diag_status)
-        self._result_writer.write_result(self._result)
+        res_str = self._result_writer.write_result(self._result)
+        self._pub_result.publish(String(data=res_str))
 
 
 @evaluator_main

--- a/sample/eagleye/scenario.yaml
+++ b/sample/eagleye/scenario.yaml
@@ -9,4 +9,4 @@ Evaluation:
   Datasets:
     - eagleye:
         VehicleId: default
-        InitialPose: null # Specifies the initial position. If null is specified, initial position estimation by GNSS is performed.
+        InitialPose: {} # Specifies the initial position. If nothing is specified, initial position estimation by GNSS is performed.

--- a/sample/yabloc/scenario.yaml
+++ b/sample/yabloc/scenario.yaml
@@ -9,4 +9,4 @@ Evaluation:
   Datasets:
     - yabloc:
         VehicleId: default
-        InitialPose: null
+        InitialPose: {} # Specifies the initial position. If nothing is specified, initial position estimation by GNSS is performed.


### PR DESCRIPTION
## Types of PR

- [X] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix

## Description

Add options to publish the conditions and results to topics in real-time.

The content is identical to the JSON output and is published to the topic as `std_msgs/String.msg`.

Currently, I only use this feature in the `planning_control` use case.

## How to review this PR

```shell
~$ ros2 topic list | rg driving_log_replayer
/driving_log_replayer/diagnostics_results
/driving_log_replayer/metrics_results

~$ ros2 topic echo /driving_log_replayer/diagnostics_results
data: '{"Result": {"Success": true, "Summary": "Passed:Condition_0 (Success), Condition_1 (Success), Condition_2 (Success), Condition_3...'
---
data: '{"Result": {"Success": true, "Summary": "Passed:Condition_0 (Success), Condition_1 (Success), Condition_2 (Success), Condition_3...'

```
## Others
