### PR TITLE
fix(planning_control): a init bug of planning-factor result

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/planning_control.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/planning_control.py
@@ -341,8 +341,11 @@ class MetricResult(ResultBase):
 
 @dataclass
 class PlanningFactor(EvaluationItem):
-    def set_frame(self, msg: PlanningFactorArray) -> dict | None:
+    def __post_init__(self) -> None:
         self.condition: PlanningFactorCondition
+        self.success = self.condition.judgement == "negative"
+
+    def set_frame(self, msg: PlanningFactorArray) -> dict | None:
         # check time condition
         if not self.condition.time.match_condition(stamp_to_float(msg.header.stamp)):
             return None


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Description
I found a bug that when a planning_factor condition has `judgement == negative`, in other words, fails when a condition is met, should have the initial status `pass` because it should be pass if there is no any planning factor.

## How to review this PR
Run any scenario with `judgement==negative` that has a rosbag containing no planning factor messages.
## Others
