### PR TITLE
feat: support override of vehicle_model and sensor_model

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/argument.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/argument.py
@@ -213,8 +213,10 @@ def update_conf_with_dataset_info(
     conf["direct_initial_pose"] = json.dumps(dataset_info.get("DirectInitialPose", {}))
     conf["goal_pose"] = json.dumps(dataset_info.get("GoalPose", {}))
     conf["t4_dataset_path"] = t4_dataset_path.as_posix()
-    conf["vehicle_model"] = yaml_obj["VehicleModel"]
-    conf["sensor_model"] = yaml_obj["SensorModel"]
+    if "vehicle_model" not in conf:
+        conf["vehicle_model"] = yaml_obj["VehicleModel"]
+    if "sensor_model" not in conf:
+        conf["sensor_model"] = yaml_obj["SensorModel"]
     conf["map_path"] = t4_dataset_path.joinpath("map").as_posix()
     conf["input_bag"] = t4_dataset_path.joinpath("input_bag").as_posix()
     conf["result_json_path"] = output_dir.joinpath("result.json").as_posix()


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [x] Upgrade of existing features
- [ ] Bugfix

## Description
P&C creates many scenarios from different products with different `vehicle_model` and `sensor_model` of rosbags.

When testing those scenarios in a different pilot-auto, we want to use the `vehicle_model` and `sensor_model` of that branch, so we want to assign `vehicle_model` and `sensor_model` by [.webauto-ci.yml](https://github.com/tier4/pilot-auto/compare/main...xtk/debug#diff-8c94ea7bde6e173c2d6b911ed85765005696d79fecdf11714848fb2186e0c1fb) like [this](https://github.com/tier4/pilot-auto/compare/main...xtk/debug#diff-8c94ea7bde6e173c2d6b911ed85765005696d79fecdf11714848fb2186e0c1fbR702-R703) 

This PR modifies the code to make such overwriting available.

## How to review this PR

## Others
