### PR TITLE
feat: better visualization for obstacle segmentation and support multipolygon

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/obstacle_segmentation.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/obstacle_segmentation.py
@@ -21,6 +21,7 @@ RECORD_TOPIC = """^/tf$\
 |^/planning/scenario_planning/trajectory$\
 |^/planning/scenario_planning/status/stop_reasons$\
 |^/driving_log_replayer_v2/.*\
+|^/driving_log_replayer/.*\
 |^/map/vector_map_marker$\
 |^/localization/kinematic_state$\
 """

--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/obstacle_segmentation.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/obstacle_segmentation.py
@@ -21,6 +21,8 @@ RECORD_TOPIC = """^/tf$\
 |^/planning/scenario_planning/trajectory$\
 |^/planning/scenario_planning/status/stop_reasons$\
 |^/driving_log_replayer_v2/.*\
+|^/map/vector_map_marker$\
+|^/localization/kinematic_state$\
 """
 
 AUTOWARE_DISABLE = {

--- a/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
@@ -382,7 +382,7 @@ def get_non_detection_area_in_base_link(
         action=Marker.ADD,
         ns="intersection",
         id=marker_id,
-        color=ColorRGBA(r=1.0, g=0.0, b=0.0, a=0.1),
+        color=ColorRGBA(r=1.0, g=0.0, b=0.0, a=0.2),
         scale=Vector3(x=1.0, y=1.0, z=1.0),
         lifetime=Duration(nanosec=200_000_000),
     )

--- a/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
@@ -39,7 +39,6 @@ import ros2_numpy
 from rosidl_runtime_py import message_to_ordereddict
 from sensor_msgs.msg import PointCloud2
 from shapely.geometry import Polygon, MultiPolygon
-from typing import Union
 import simplejson as json
 from std_msgs.msg import ColorRGBA
 from std_msgs.msg import Header

--- a/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
@@ -389,13 +389,13 @@ def get_non_detection_area_in_base_link(
     list_p_stamped_base_link: list[PointStamped] = []
     poly: Union[Polygon, MultiPolygon]
     for poly in poly.geoms:
-            for i, shapely_point in enumerate(poly.exterior.coords):
+        for i, shapely_point in enumerate(poly.exterior.coords):
                 if i != len(poly.exterior.coords) - 1:
                     p_stamped_map = PointStamped(
                         header=header,
                         point=Point(x=shapely_point[0], y=shapely_point[1], z=average_z),
                     )
-                    list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))     
+                    list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))         
     # create floor polygon
     for p_base_link in list_p_stamped_base_link:
         p_base_link.point.z = z_min

--- a/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
@@ -39,6 +39,7 @@ import ros2_numpy
 from rosidl_runtime_py import message_to_ordereddict
 from sensor_msgs.msg import PointCloud2
 from shapely.geometry import Polygon
+from shapely.geometry import MultiPolygon
 import simplejson as json
 from std_msgs.msg import ColorRGBA
 from std_msgs.msg import Header
@@ -386,13 +387,23 @@ def get_non_detection_area_in_base_link(
     )
     list_intersection_area = []
     list_p_stamped_base_link: list[PointStamped] = []
-    for i, shapely_point in enumerate(intersection_polygon.exterior.coords):
-        if i != len(intersection_polygon.exterior.coords) - 1:
-            p_stamped_map = PointStamped(
-                header=header,
-                point=Point(x=shapely_point[0], y=shapely_point[1], z=average_z),
-            )
-            list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))
+    if isinstance(intersection_polygon, Polygon):
+        for i, shapely_point in enumerate(intersection_polygon.exterior.coords):
+            if i != len(intersection_polygon.exterior.coords) - 1:
+                p_stamped_map = PointStamped(
+                    header=header,
+                    point=Point(x=shapely_point[0], y=shapely_point[1], z=average_z),
+                )
+                list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))
+    elif isinstance(intersection_polygon, MultiPolygon):
+        for poly in MultiPolygon.geoms:
+            for i, shapely_point in enumerate(poly.exterior.coords):
+                if i != len(intersection_polygon.exterior.coords) - 1:
+                    p_stamped_map = PointStamped(
+                        header=header,
+                        point=Point(x=shapely_point[0], y=shapely_point[1], z=average_z),
+                    )
+                    list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))
     # create floor polygon
     for p_base_link in list_p_stamped_base_link:
         p_base_link.point.z = z_min

--- a/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
@@ -387,20 +387,14 @@ def get_non_detection_area_in_base_link(
     )
     list_intersection_area = []
     list_p_stamped_base_link: list[PointStamped] = []
-    if isinstance(intersection_polygon, Polygon):
-        for i, shapely_point in enumerate(intersection_polygon.exterior.coords):
-            if i != len(intersection_polygon.exterior.coords) - 1:
-                p_stamped_map = PointStamped(
-                    header=header,
-                    point=Point(x=shapely_point[0], y=shapely_point[1], z=average_z),
-                )
-                list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))
+    polygons_to_process = []    
+    if isinstance(intersection_polygon, Polygon):  # Handle single Polygon
+        polygons_to_process.append(intersection_polygon)
     elif isinstance(intersection_polygon, MultiPolygon):
-        single_polygon_multipolygon = MultiPolygon([Polygon])
-        poly: Union[Polygon, MultiPolygon]
-        for poly in single_polygon_multipolygon.geoms:
-            for i, shapely_point in enumerate(poly.exterior.coords):
-                if i != len(intersection_polygon.exterior.coords) - 1:
+        polygons_to_process.extend(intersection_polygon.geoms) # Use .geoms to get a list of individual polygons from the MultiPolygon
+    for poly in polygons_to_process:
+        for i, shapely_point in enumerate(poly.exterior.coords):
+                if i != len(poly.exterior.coords) - 1:
                     p_stamped_map = PointStamped(
                         header=header,
                         point=Point(x=shapely_point[0], y=shapely_point[1], z=average_z),

--- a/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
@@ -387,19 +387,15 @@ def get_non_detection_area_in_base_link(
     )
     list_intersection_area = []
     list_p_stamped_base_link: list[PointStamped] = []
-    polygons_to_process = []    
-    if isinstance(intersection_polygon, Polygon):  # Handle single Polygon
-        polygons_to_process.append(intersection_polygon)
-    elif isinstance(intersection_polygon, MultiPolygon):
-        polygons_to_process.extend(intersection_polygon.geoms) # Use .geoms to get a list of individual polygons from the MultiPolygon
-    for poly in polygons_to_process:
-        for i, shapely_point in enumerate(poly.exterior.coords):
+    poly: Union[Polygon, MultiPolygon]
+    for poly in poly.geoms:
+            for i, shapely_point in enumerate(poly.exterior.coords):
                 if i != len(poly.exterior.coords) - 1:
                     p_stamped_map = PointStamped(
                         header=header,
                         point=Point(x=shapely_point[0], y=shapely_point[1], z=average_z),
                     )
-                    list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))
+                    list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))     
     # create floor polygon
     for p_base_link in list_p_stamped_base_link:
         p_base_link.point.z = z_min

--- a/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
@@ -396,7 +396,8 @@ def get_non_detection_area_in_base_link(
                 )
                 list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))
     elif isinstance(intersection_polygon, MultiPolygon):
-        for poly in MultiPolygon.geoms:
+        single_polygon_multipolygon = MultiPolygon([Polygon])
+        for poly in single_polygon_multipolygon.geoms:
             for i, shapely_point in enumerate(poly.exterior.coords):
                 if i != len(intersection_polygon.exterior.coords) - 1:
                     p_stamped_map = PointStamped(

--- a/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
@@ -382,7 +382,7 @@ def get_non_detection_area_in_base_link(
         action=Marker.ADD,
         ns="intersection",
         id=marker_id,
-        color=ColorRGBA(r=1.0, g=0.0, b=0.0, a=0.2),
+        color=ColorRGBA(r=1.0, g=0.0, b=0.0, a=0.1),
         scale=Vector3(x=1.0, y=1.0, z=1.0),
         lifetime=Duration(nanosec=200_000_000),
     )

--- a/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
@@ -38,8 +38,8 @@ from pydantic import field_validator
 import ros2_numpy
 from rosidl_runtime_py import message_to_ordereddict
 from sensor_msgs.msg import PointCloud2
-from shapely.geometry import Polygon
-from shapely.geometry import MultiPolygon
+from shapely.geometry import Polygon, MultiPolygon
+from typing import Union
 import simplejson as json
 from std_msgs.msg import ColorRGBA
 from std_msgs.msg import Header
@@ -397,6 +397,7 @@ def get_non_detection_area_in_base_link(
                 list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))
     elif isinstance(intersection_polygon, MultiPolygon):
         single_polygon_multipolygon = MultiPolygon([Polygon])
+        poly: Union[Polygon, MultiPolygon]
         for poly in single_polygon_multipolygon.geoms:
             for i, shapely_point in enumerate(poly.exterior.coords):
                 if i != len(intersection_polygon.exterior.coords) - 1:

--- a/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/obstacle_segmentation.py
@@ -387,15 +387,23 @@ def get_non_detection_area_in_base_link(
     )
     list_intersection_area = []
     list_p_stamped_base_link: list[PointStamped] = []
-    poly: Union[Polygon, MultiPolygon]
-    for poly in poly.geoms:
-        for i, shapely_point in enumerate(poly.exterior.coords):
-                if i != len(poly.exterior.coords) - 1:
+    if isinstance(intersection_polygon, Polygon):
+        for i, shapely_point in enumerate(intersection_polygon.exterior.coords):
+            if i != len(intersection_polygon.exterior.coords) - 1:
+                p_stamped_map = PointStamped(
+                    header=header,
+                    point=Point(x=shapely_point[0], y=shapely_point[1], z=average_z),
+                )
+                list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))
+    elif isinstance(intersection_polygon, MultiPolygon):
+        for poly in intersection_polygon.geoms:
+            for i, shapely_point in enumerate(poly.exterior.coords):
+                 if i != len(poly.exterior.coords) - 1:
                     p_stamped_map = PointStamped(
                         header=header,
                         point=Point(x=shapely_point[0], y=shapely_point[1], z=average_z),
                     )
-                    list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))         
+                    list_p_stamped_base_link.append(do_transform_point(p_stamped_map, base_link_to_map))
     # create floor polygon
     for p_base_link in list_p_stamped_base_link:
         p_base_link.point.z = z_min

--- a/driving_log_replayer_v2/scripts/obstacle_segmentation_evaluator_node.py
+++ b/driving_log_replayer_v2/scripts/obstacle_segmentation_evaluator_node.py
@@ -58,6 +58,10 @@ import driving_log_replayer_v2.perception_eval_conversions as eval_conversions
 from driving_log_replayer_v2_analyzer.data import convert_str_to_dist_type
 from driving_log_replayer_v2_msgs.msg import ObstacleSegmentationMarker
 from driving_log_replayer_v2_msgs.msg import ObstacleSegmentationMarkerArray
+import shapely
+from shapely.errors import TopologicalError
+from shapely.geometry import Polygon
+from shapely.validation import make_valid
 
 if TYPE_CHECKING:
     from perception_eval.common.dataset import FrameGroundTruth
@@ -341,6 +345,10 @@ class ObstacleSegmentationEvaluator(DLREvaluatorV2):
             header,
             map_to_baselink,
         )
+        # Ensure the proposed area geometry is valid
+        if not proposed_area_in_map.is_valid:
+            proposed_area_in_map = make_valid(proposed_area_in_map)
+
         # get intersection
         marker_id = 0
         ego_point = set_ego_point(map_to_baselink)
@@ -351,24 +359,29 @@ class ObstacleSegmentationEvaluator(DLREvaluatorV2):
         )
         for road in near_road_lanelets:
             poly_lanelet = to_shapely_polygon(road)
-            i_area = poly_lanelet.intersection(proposed_area_in_map)
-            if not i_area.is_empty:
-                marker_id += 1
-                marker, area = get_non_detection_area_in_base_link(
-                    i_area,
-                    header,
-                    s_proposed_area.z_min,
-                    s_proposed_area.z_max,
-                    average_z,
-                    base_link_to_map,
-                    marker_id,
-                )
-                non_detection_area_markers.markers.append(marker)  # base_link
-                non_detection_areas.append(area)  # base_link
+            # Ensure the lanelet geometry is valid
+            if not poly_lanelet.is_valid:
+                poly_lanelet = make_valid(poly_lanelet)
+            try:
+                i_area = poly_lanelet.intersection(proposed_area_in_map)
+                if not i_area.is_empty:
+                    marker_id += 1
+                    marker, area = get_non_detection_area_in_base_link(
+                        i_area,
+                        header,
+                        s_proposed_area.z_min,
+                        s_proposed_area.z_max,
+                        average_z,
+                        base_link_to_map,
+                        marker_id,
+                    )
+                    non_detection_area_markers.markers.append(marker)  # base_link
+                    non_detection_areas.append(area)  # base_link
+            except shapely.errors.TopologicalError as e:
+                self.get_logger().error(f"TopologicalError during intersection: {e}")
+                continue
         # create marker and polygon for perception_eval
         return non_detection_area_markers, non_detection_areas
-
-
 @evaluator_main
 def main() -> DLREvaluatorV2:
     return ObstacleSegmentationEvaluator("obstacle_segmentation_evaluator")

--- a/driving_log_replayer_v2/scripts/obstacle_segmentation_evaluator_node.py
+++ b/driving_log_replayer_v2/scripts/obstacle_segmentation_evaluator_node.py
@@ -35,6 +35,8 @@ from rclpy.qos import QoSReliabilityPolicy
 import ros2_numpy
 from rosidl_runtime_py import message_to_ordereddict
 from sensor_msgs.msg import PointCloud2
+import shapely
+from shapely.validation import make_valid
 import simplejson as json
 from std_msgs.msg import Header
 from std_msgs.msg import String
@@ -58,10 +60,6 @@ import driving_log_replayer_v2.perception_eval_conversions as eval_conversions
 from driving_log_replayer_v2_analyzer.data import convert_str_to_dist_type
 from driving_log_replayer_v2_msgs.msg import ObstacleSegmentationMarker
 from driving_log_replayer_v2_msgs.msg import ObstacleSegmentationMarkerArray
-import shapely
-from shapely.errors import TopologicalError
-from shapely.geometry import Polygon
-from shapely.validation import make_valid
 
 if TYPE_CHECKING:
     from perception_eval.common.dataset import FrameGroundTruth
@@ -382,6 +380,8 @@ class ObstacleSegmentationEvaluator(DLREvaluatorV2):
                 continue
         # create marker and polygon for perception_eval
         return non_detection_area_markers, non_detection_areas
+
+
 @evaluator_main
 def main() -> DLREvaluatorV2:
     return ObstacleSegmentationEvaluator("obstacle_segmentation_evaluator")


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [X] Upgrade of existing features
- [ ] Bugfix

## Description

I optimize the visualization for obstacle_segmentation tests by:
- added map and ego topics to save for visualization
- modified markers in func `get_non_detection_area_in_base_link`


**This PR is created based on the branch [obstacle_segmentation_multipolygon](https://github.com/tier4/driving_log_replayer_v2/tree/exp/obstacle_segmentation_multipolygon)**
- This branch is for using multiple polygons for obstacle_segmentation tests, which is created by  @MyatmonThiri
- To @MyatmonThiri : I want to merge your branch and my updates to develop together. How do you think?


Parent JIRA ticket: https://tier4.atlassian.net/browse/T4DEV-31233

## How to review this PR
I ran the tests for two catalogs:
- https://evaluation.ci.tier4.jp/evaluation/reports/6349733c-0d97-56c4-8a6c-fe35224a0800?project_id=autoware_dev
- https://evaluation.tier4.jp/evaluation/reports/f4937b14-c892-5534-93aa-c9fd7f582c71?project_id=X8ft5pPN

visualization in Evaluator:
<img width="2957" height="1620" alt="image" src="https://github.com/user-attachments/assets/ff2d1b0b-92e3-408c-a3fa-8027d75fe952" />

visualization in Lichtblick ([usage guide](https://tier4.atlassian.net/wiki/spaces/CT/pages/4124934180/DLR+Lichtblick)):
<img width="1600" height="943" alt="image" src="https://github.com/user-attachments/assets/52767518-3f0f-4739-962d-4f4d01ac71e4" />

## Others
