### PR TITLE
fix(ndt_convergence): a rosbag bug on the Evaluator

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/ndt_convergence.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/ndt_convergence.py
@@ -20,13 +20,14 @@ from launch.actions import DeclareLaunchArgument
 from launch.actions import GroupAction
 from launch.actions import IncludeLaunchDescription
 from launch.actions import LogInfo
+from launch.actions import OpaqueFunction
 from launch.launch_description_sources import AnyLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
-from driving_log_replayer_v2.launch.util import output_dummy_result_bag
+from driving_log_replayer_v2.launch.rosbag import launch_bag_recorder
 from driving_log_replayer_v2.launch.util import output_dummy_result_jsonl
 
-RECORD_TOPIC = ""
+RECORD_TOPIC = "/.*"
 
 AUTOWARE_DISABLE = {}
 
@@ -49,7 +50,6 @@ def launch_ndt_convergence(context: LaunchContext) -> list:
 
     # Output dummies to comply with Evaluator specifications
     output_dummy_result_jsonl(conf["result_json_path"], summary="NDT Convergence always success")
-    output_dummy_result_bag(conf["result_bag_path"])
 
     launch_args = {
         "map_path": conf["map_path"] + "/pointcloud_map.pcd",
@@ -57,6 +57,9 @@ def launch_ndt_convergence(context: LaunchContext) -> list:
         "save_dir": conf["result_archive_path"],
     }
     return [
+        OpaqueFunction(
+            function=launch_bag_recorder
+        ),  # record nothing, just for Evaluator specifications
         GroupAction(
             [
                 IncludeLaunchDescription(
@@ -66,7 +69,7 @@ def launch_ndt_convergence(context: LaunchContext) -> list:
                     launch_arguments=launch_args.items(),
                 ),
             ]
-        )
+        ),
     ]
 
 

--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/ndt_convergence.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/ndt_convergence.py
@@ -27,7 +27,7 @@ from launch.substitutions import LaunchConfiguration
 from driving_log_replayer_v2.launch.rosbag import launch_bag_recorder
 from driving_log_replayer_v2.launch.util import output_dummy_result_jsonl
 
-RECORD_TOPIC = "/.*"
+RECORD_TOPIC = "^$"  # matches no topics, so nothing will be recorded
 
 AUTOWARE_DISABLE = {}
 

--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/util.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/util.py
@@ -25,11 +25,3 @@ def output_dummy_result_jsonl(result_json_path_str: str, summary: str = "RecordO
     }
     with Path(jsonl_path_str).open("w") as f:
         json.dump(dummy_result, f)
-
-
-def output_dummy_result_bag(result_bag_path_str: str) -> None:
-    result_bag_path = Path(result_bag_path_str)
-    result_bag_path.mkdir(parents=True, exist_ok=True)
-    # create dummy bag file
-    dummy_bag_path = result_bag_path / "dummy_0.mcap"
-    dummy_bag_path.touch()


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [X] Bugfix

## Description
The NDT test has been unavailable in the Evaluator for several months due to the following bug:
<img width="1115" height="124" alt="image" src="https://github.com/user-attachments/assets/353198b3-2426-42fc-a841-e6d550fdf4a5" />

This is because the generated dummy rosbag by DLRv2 is not valid.
This PR launches bag_recorder, although recording nothing, to generate a valid dummy rosbag.

## How to review this PR
Check evaluator result: https://evaluation.tier4.jp/evaluation/reports/55057fc7-7032-5f54-96c0-21baaa9bbbb1?project_id=autoware_dev

## Others
