### PR TITLE
chore(planning_control): output results when planning_factors is empt as well

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/planning_control.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/planning_control.py
@@ -357,8 +357,6 @@ class PlanningFactor(EvaluationItem):
                 "Behavior": "NO_FACTOR",
             }
         else:
-            frame_success = "Fail"
-
             # get factors[0] # factorsはarrayになっているが、実際には1個しか入ってない。
             info_dict = {}
             condition_met = True
@@ -382,8 +380,8 @@ class PlanningFactor(EvaluationItem):
             condition_met if self.condition.judgement == "positive" else not condition_met
         )
         if condition_met:
-            frame_success = "Success"
             self.passed += 1
+        frame_success = "Success" if condition_met else "Fail"
 
         self.success = (
             self.passed > 0

--- a/driving_log_replayer_v2/driving_log_replayer_v2/planning_control.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/planning_control.py
@@ -349,27 +349,33 @@ class PlanningFactor(EvaluationItem):
         # check time condition
         if not self.condition.time.match_condition(stamp_to_float(msg.header.stamp)):
             return None
-        if len(msg.factors) == 0:
-            return None
 
         self.total += 1
-        frame_success = "Fail"
+        if len(msg.factors) == 0:
+            condition_met = False
+            info_dict = {
+                "Behavior": "NO_FACTOR",
+            }
+        else:
+            frame_success = "Fail"
 
-        # get factors[0] # factorsはarrayになっているが、実際には1個しか入ってない。
-        info_dict = {}
-        condition_met = True
+            # get factors[0] # factorsはarrayになっているが、実際には1個しか入ってない。
+            info_dict = {}
+            condition_met = True
 
-        if self.condition.area is not None:
-            in_range, info_dict_area = self.judge_in_range(msg.factors[0].control_points[0].pose)
-            info_dict.update(info_dict_area)
-            condition_met &= (
-                in_range if self.condition.area.area_condition == "inside" else not in_range
-            )
+            if self.condition.area is not None:
+                in_range, info_dict_area = self.judge_in_range(
+                    msg.factors[0].control_points[0].pose
+                )
+                info_dict.update(info_dict_area)
+                condition_met &= (
+                    in_range if self.condition.area.area_condition == "inside" else not in_range
+                )
 
-        if self.condition.behavior is not None:
-            behavior_met, info_dict_behavior = self.judge_behavior(msg.factors[0])
-            info_dict.update(info_dict_behavior)
-            condition_met &= behavior_met
+            if self.condition.behavior is not None:
+                behavior_met, info_dict_behavior = self.judge_behavior(msg.factors[0])
+                info_dict.update(info_dict_behavior)
+                condition_met &= behavior_met
 
         # Check if the condition is met based on judgement type
         condition_met = (


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [X] Upgrade of existing features
- [ ] Bugfix

## Description
When `factors` in the PlanningFactor message contain no factor, DLR will record nothing, just like that topic publishes nothing (≒ this module has died/doesn't work).

However, we want to distinguish these two situations (module didn't activate / module didn't work) when checking the DLR test results, so this PR lets the result of empty factors also be recorded in the result.

## How to review this PR

Evaluator: https://evaluation.tier4.jp/evaluation/reports/51f3c937-3b2a-5d62-8a9d-ee0f9073e7aa?project_id=x2_dev

Check a test_case's `planning_factor_result.jsonl`, most of lines sould be:

```
{"Result": {"Success": true, "Summary": "Passed:check run_out (Success)"}, "Stamp": {"System": 1759891594.758527, "ROS": 1754282426.3438594}, "Frame": {"check run_out": {"Result": {"Total": "Success", "Frame": "Success"}, "Info": {"Behavior": "NO_FACTOR"}}}}
```

## Others
