### PR TITLE
feat(perception_reproducer): add pub-route option

### DIFF
--- a/docs/use_case/perception_reproducer.en.md
+++ b/docs/use_case/perception_reproducer.en.md
@@ -137,7 +137,7 @@ Configuration options:
 
 ### Route Method
 
-When `goal_method` is set to `set_goal_from_scenario` and not set `GoalPose`, you should use `--pub-route` flag of `perception_reproducer`　(under development).
+When `goal_method` is set to `set_goal_from_scenario` and not set `GoalPose`, you should use `--replay-route` flag of `perception_reproducer`.
 
 See [scenario format](../scenario_format/index.en.md#goal_method) for details on `goal_method`.
 

--- a/docs/use_case/perception_reproducer.ja.md
+++ b/docs/use_case/perception_reproducer.ja.md
@@ -138,7 +138,7 @@ Published topics:
 ### ルート設定方法
 
 走行ルートはシナリオYAMLのデータセットレベルにある `goal_method` フィールドで設定できる。
-`goal_method` が `set_goal_from_scenario` かつ`GoalPose`を設定しない場合、 `perception_reproducer` の`--pub-route` フラグを使うべき（未実装）
+`goal_method` が `set_goal_from_scenario` かつ`GoalPose`を設定しない場合、 `perception_reproducer` の`--replay-route` フラグを使う。
 
 `goal_method` の詳細については[シナリオフォーマット](../scenario_format/index.ja.md#goal_method)を参照。
 

--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/rosbag.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/rosbag.py
@@ -247,5 +247,7 @@ def launch_perception_reproducer(context: LaunchContext) -> list:
         cmd.extend(["--search-radius", str(reproducer_config["search_radius"])])
     if reproducer_config.get("reproduce_cool_down") is not None:
         cmd.extend(["--reproduce-cool-down", str(reproducer_config["reproduce_cool_down"])])
+    if reproducer_config.get("pub_route", False):
+        cmd.append("--pub-route")
 
     return [ExecuteProcess(cmd=cmd, output="screen", on_exit=ShutdownOnce())]

--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/rosbag.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/rosbag.py
@@ -247,7 +247,7 @@ def launch_perception_reproducer(context: LaunchContext) -> list:
         cmd.extend(["--search-radius", str(reproducer_config["search_radius"])])
     if reproducer_config.get("reproduce_cool_down") is not None:
         cmd.extend(["--reproduce-cool-down", str(reproducer_config["reproduce_cool_down"])])
-    if reproducer_config.get("pub_route", False):
-        cmd.append("--pub-route")
+    if reproducer_config.get("replay_route", False):
+        cmd.append("--replay-route")
 
     return [ExecuteProcess(cmd=cmd, output="screen", on_exit=ShutdownOnce())]

--- a/driving_log_replayer_v2/driving_log_replayer_v2/perception_reproducer.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/perception_reproducer.py
@@ -60,7 +60,7 @@ class PerceptionReproducerConfig(BaseModel):
     reproduce_cool_down: float = Field(999.0, ge=0.0)
     tracked_object: bool = False
     search_radius: float = Field(1.5, ge=0.0)
-    pub_route: bool = False
+    replay_route: bool = False
 
 
 class _DeprecatedTimeField:

--- a/driving_log_replayer_v2/driving_log_replayer_v2/perception_reproducer.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/perception_reproducer.py
@@ -60,6 +60,7 @@ class PerceptionReproducerConfig(BaseModel):
     reproduce_cool_down: float = Field(999.0, ge=0.0)
     tracked_object: bool = False
     search_radius: float = Field(1.5, ge=0.0)
+    pub_route: bool = False
 
 
 class _DeprecatedTimeField:

--- a/sample/perception_reproducer/scenario_sample.yaml
+++ b/sample/perception_reproducer/scenario_sample.yaml
@@ -32,7 +32,7 @@ Evaluation:
 
   perception_reproducer_config:
     noise: false
-    pub_route: false
+    replay_route: false
     reproduce_cool_down: 999.0
     search_radius: 1.5
     tracked_object: false


### PR DESCRIPTION
## Types of PR

- [X] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix

## Description
Add replay-route option that publishes the route from the rosbag via perception reproducer.
perception reproducer side PR: https://github.com/autowarefoundation/autoware_tools/pull/369

## How to review this PR

## Others
