### PR TITLE
feat: add dual trajectory open loop evalautioin metrics

### DIFF
--- a/driving_log_replayer_v2/launch/post_process.launch.py
+++ b/driving_log_replayer_v2/launch/post_process.launch.py
@@ -269,7 +269,9 @@ def time_step_based_trajectory(conf: dict[str, str]) -> ProcessInfo:
         OnProcessExit(
             target_action=optimized_analysis,
             on_exit=[
-                LogInfo(msg="run time_step_based_trajectory analysis for raw diffusion trajectory."),
+                LogInfo(
+                    msg="run time_step_based_trajectory analysis for raw diffusion trajectory."
+                ),
                 raw_analysis,
             ],
         )

--- a/driving_log_replayer_v2/launch/post_process.launch.py
+++ b/driving_log_replayer_v2/launch/post_process.launch.py
@@ -265,7 +265,7 @@ def time_step_based_trajectory(conf: dict[str, str]) -> ProcessInfo:
     raw_analysis = ExecuteProcess(
         cmd=raw_analysis_cmd, output="screen", name="time_step_analysis_raw"
     )
-    raw_analysis_event_handler = RegisterEventHandler(
+    start_raw_analysis_on_optimized_exit = RegisterEventHandler(
         OnProcessExit(
             target_action=optimized_analysis,
             on_exit=[
@@ -281,7 +281,7 @@ def time_step_based_trajectory(conf: dict[str, str]) -> ProcessInfo:
         process_list=[
             LogInfo(msg="run time_step_based_trajectory analysis for optimized trajectory."),
             optimized_analysis,
-            raw_analysis_event_handler,
+            start_raw_analysis_on_optimized_exit,
         ],
         last_action=raw_analysis,
     )

--- a/driving_log_replayer_v2/launch/post_process.launch.py
+++ b/driving_log_replayer_v2/launch/post_process.launch.py
@@ -227,25 +227,61 @@ def planning_control(conf: dict[str, str]) -> ProcessInfo:
 def time_step_based_trajectory(conf: dict[str, str]) -> ProcessInfo:
     # This use_case is record_only so not create result_archive directory.
     Path(conf["result_archive_path"]).mkdir(parents=True, exist_ok=True)
-    time_step_analysis_cmd = [
+    optimized_result_archive_path = Path(conf["result_archive_path"]).joinpath("optimized")
+    raw_result_archive_path = Path(conf["result_archive_path"]).joinpath("raw")
+    optimized_result_archive_path.mkdir(parents=True, exist_ok=True)
+    raw_result_archive_path.mkdir(parents=True, exist_ok=True)
+
+    optimized_analysis_cmd = [
         "ros2",
         "launch",
         "autoware_planning_data_analyzer",
         "planning_data_analyzer.launch.xml",
         f"bag_path:={conf['result_bag_path']}/result_bag_0.mcap",
-        f"output_dir:={conf['result_archive_path']}",
+        f"output_dir:={optimized_result_archive_path}",
+        "trajectory_topic:=/planning/trajectory",
+        "open_loop_metric_variant:=optimized",
+        f"gt_source_mode:={conf['gt_source_mode']}",
+        f"gt_trajectory_topic:={conf['gt_trajectory_topic']}",
+        f"gt_sync_tolerance_ms:={conf['gt_sync_tolerance_ms']}",
+    ]
+    raw_analysis_cmd = [
+        "ros2",
+        "launch",
+        "autoware_planning_data_analyzer",
+        "planning_data_analyzer.launch.xml",
+        f"bag_path:={conf['result_bag_path']}/result_bag_0.mcap",
+        f"output_dir:={raw_result_archive_path}",
+        "trajectory_topic:=/planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/output/trajectory",
+        "open_loop_metric_variant:=raw",
         f"gt_source_mode:={conf['gt_source_mode']}",
         f"gt_trajectory_topic:={conf['gt_trajectory_topic']}",
         f"gt_sync_tolerance_ms:={conf['gt_sync_tolerance_ms']}",
     ]
 
-    time_step_analysis = ExecuteProcess(
-        cmd=time_step_analysis_cmd, output="screen", name="time_step_analysis"
+    optimized_analysis = ExecuteProcess(
+        cmd=optimized_analysis_cmd, output="screen", name="time_step_analysis_optimized"
+    )
+    raw_analysis = ExecuteProcess(
+        cmd=raw_analysis_cmd, output="screen", name="time_step_analysis_raw"
+    )
+    raw_analysis_event_handler = RegisterEventHandler(
+        OnProcessExit(
+            target_action=optimized_analysis,
+            on_exit=[
+                LogInfo(msg="run time_step_based_trajectory analysis for raw diffusion trajectory."),
+                raw_analysis,
+            ],
+        )
     )
 
     return ProcessInfo(
-        process_list=[LogInfo(msg="run time_step_based_trajectory analysis."), time_step_analysis],
-        last_action=time_step_analysis,
+        process_list=[
+            LogInfo(msg="run time_step_based_trajectory analysis for optimized trajectory."),
+            optimized_analysis,
+            raw_analysis_event_handler,
+        ],
+        last_action=raw_analysis,
     )
 
 


### PR DESCRIPTION
## Types of PR

- [x] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix

## Description

### Summary


- `/planning/trajectory`
- `/planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/output/trajectory`


Both results are saved into the same `result_bag_0.mcap` with separate topic namespaces:

- `/open_loop/metrics/optimized/...`
- `/open_loop/metrics/raw/...`

### Changes

- run `autoware_planning_data_analyzer` twice in DLR post-process
- add analyzer support for namespaced open-loop output topics
- add a test for variant-specific topic naming


## How to review this PR

Regarding the `autoware_planning_data_analyzer`'s modification, please refer to this [PR](https://github.com/autowarefoundation/autoware_tools/pull/371)

## Others
