### PR TITLE
feat: add launch_post_engage_initial_pose_node for reproducer test

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/argument.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/argument.py
@@ -255,6 +255,10 @@ def update_conf_with_dataset_info(
 
     if conf["use_case"] in ["perception_reproducer"]:
         conf["timeout_s"] = yaml_obj["Evaluation"]["Conditions"]["timeout_s"]
+        reproducer_config = yaml_obj["Evaluation"].get("perception_reproducer_config", {})
+        conf["move_ego_forward_after_engage_m"] = str(
+            reproducer_config.get("move_ego_forward_after_engage_m", 0.1)
+        )
 
     # higher priority to argument than scenario
     if conf["publish_profile"] == "" and yaml_obj.get("publish_profile"):

--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/perception_reproducer.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/perception_reproducer.py
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+
 from launch import LaunchContext
 from launch.actions import DeclareLaunchArgument
+from launch.actions import LogInfo
 from launch.actions import OpaqueFunction
+from launch.actions import RegisterEventHandler
+from launch.event_handlers import OnProcessExit
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
@@ -25,6 +30,8 @@ from driving_log_replayer_v2.launch.use_case import launch_autoware
 from driving_log_replayer_v2.launch.use_case import launch_evaluator_node
 from driving_log_replayer_v2.launch.use_case import launch_goal_pose_node
 from driving_log_replayer_v2.launch.use_case import launch_initial_pose_node
+from driving_log_replayer_v2.pose import offset_pose_dict_forward
+from driving_log_replayer_v2.pose import pose_str_to_dict
 
 RECORD_TOPIC = """^/tf$\
 |^/tf_static$\
@@ -63,22 +70,62 @@ NODE_PARAMS: dict[str, LaunchConfiguration] = {}
 USE_CASE_ARGS: list[DeclareLaunchArgument] = []
 
 
-def launch_engage_node(context: LaunchContext) -> list:
+def _get_post_engage_direct_initial_pose(conf: dict) -> str | None:
+    base_pose = conf["direct_initial_pose"]
+    if base_pose == "{}":
+        base_pose = conf["initial_pose"]
+    if base_pose == "{}":
+        return None
+    shifted_pose_dict = offset_pose_dict_forward(pose_str_to_dict(base_pose), 0.1)
+    return json.dumps(shifted_pose_dict)
+
+
+def launch_engage_sequence(context: LaunchContext) -> list:
     conf = context.launch_configurations
 
-    params = {
-        "use_sim_time": False,
-        "timeout_s": float(conf["timeout_s"]),
-    }
+    engage_node = Node(
+        package="driving_log_replayer_v2",
+        namespace="/driving_log_replayer_v2",
+        executable="engage_node.py",
+        output="screen",
+        name="engage_node",
+        parameters=[
+            {
+                "use_sim_time": False,
+                "timeout_s": float(conf["timeout_s"]),
+            }
+        ],
+    )
+
+    def launch_post_engage_initial_pose_node(_: LaunchContext) -> list:
+        post_engage_direct_initial_pose = _get_post_engage_direct_initial_pose(conf)
+        if post_engage_direct_initial_pose is None:
+            return [LogInfo(msg="post_engage_initial_pose_node is not activated")]
+        return [
+            LogInfo(msg="engage_node exited. launching post_engage_initial_pose_node"),
+            Node(
+                package="driving_log_replayer_v2",
+                namespace="/driving_log_replayer_v2",
+                executable="initial_pose_node.py",
+                output="screen",
+                name="post_engage_initial_pose_node",
+                parameters=[
+                    {
+                        "use_sim_time": False,
+                        "initial_pose": "{}",
+                        "direct_initial_pose": post_engage_direct_initial_pose,
+                    }
+                ],
+            ),
+        ]
 
     return [
-        Node(
-            package="driving_log_replayer_v2",
-            namespace="/driving_log_replayer_v2",
-            executable="engage_node.py",
-            output="screen",
-            name="engage_node",
-            parameters=[params],
+        engage_node,
+        RegisterEventHandler(
+            OnProcessExit(
+                target_action=engage_node,
+                on_exit=[OpaqueFunction(function=launch_post_engage_initial_pose_node)],
+            )
         ),
     ]
 
@@ -92,5 +139,5 @@ def launch_perception_reproducer_use_case() -> list:
         OpaqueFunction(function=launch_evaluator_node),
         OpaqueFunction(function=launch_initial_pose_node),
         OpaqueFunction(function=launch_goal_pose_node),
-        OpaqueFunction(function=launch_engage_node),
+        OpaqueFunction(function=launch_engage_sequence),
     ]

--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/perception_reproducer.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/perception_reproducer.py
@@ -71,12 +71,19 @@ USE_CASE_ARGS: list[DeclareLaunchArgument] = []
 
 
 def _get_post_engage_direct_initial_pose(conf: dict) -> str | None:
+    move_ego_forward_after_engage_m = float(conf["move_ego_forward_after_engage_m"])
+    if move_ego_forward_after_engage_m == 0.0:
+        return None
     base_pose = conf["direct_initial_pose"]
     if base_pose == "{}":
         base_pose = conf["initial_pose"]
     if base_pose == "{}":
         return None
-    shifted_pose_dict = offset_pose_dict_forward(pose_str_to_dict(base_pose), 0.1)
+    # Perturb ego after engage so the planner stops publishing a stopping trajectory.
+    shifted_pose_dict = offset_pose_dict_forward(
+        pose_str_to_dict(base_pose),
+        move_ego_forward_after_engage_m,
+    )
     return json.dumps(shifted_pose_dict)
 
 

--- a/driving_log_replayer_v2/driving_log_replayer_v2/perception_reproducer.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/perception_reproducer.py
@@ -61,6 +61,7 @@ class PerceptionReproducerConfig(BaseModel):
     tracked_object: bool = False
     search_radius: float = Field(1.5, ge=0.0)
     replay_route: bool = False
+    move_ego_forward_after_engage_m: float = 0.1
 
 
 class _DeprecatedTimeField:

--- a/driving_log_replayer_v2/driving_log_replayer_v2/pose.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/pose.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import math
 from typing import Any
 
 from geometry_msgs.msg import Point
@@ -39,8 +40,44 @@ def pose_str_to_dict(pose_str: str) -> dict:
     return convert_to_float(pose_dict_number)
 
 
-def arg_to_initial_pose(pose_str: str) -> PoseWithCovarianceStamped:
-    pose_dict = pose_str_to_dict(pose_str)
+def offset_pose_dict_forward(pose_dict: dict, offset_m: float) -> dict:
+    orientation = pose_dict["orientation"]
+    qx = orientation["x"]
+    qy = orientation["y"]
+    qz = orientation["z"]
+    qw = orientation["w"]
+
+    norm = math.sqrt(qx * qx + qy * qy + qz * qz + qw * qw)
+    if norm == 0.0:
+        msg = "orientation quaternion norm is zero"
+        raise ValueError(msg)
+
+    qx /= norm
+    qy /= norm
+    qz /= norm
+    qw /= norm
+
+    forward_x = 1.0 - 2.0 * (qy * qy + qz * qz)
+    forward_y = 2.0 * (qx * qy + qz * qw)
+    forward_z = 2.0 * (qx * qz - qy * qw)
+
+    position = pose_dict["position"]
+    return {
+        "position": {
+            "x": position["x"] + offset_m * forward_x,
+            "y": position["y"] + offset_m * forward_y,
+            "z": position["z"] + offset_m * forward_z,
+        },
+        "orientation": {
+            "x": orientation["x"],
+            "y": orientation["y"],
+            "z": orientation["z"],
+            "w": orientation["w"],
+        },
+    }
+
+
+def pose_dict_to_initial_pose(pose_dict: dict) -> PoseWithCovarianceStamped:
     covariance = np.array(
         [
             0.25,
@@ -89,6 +126,11 @@ def arg_to_initial_pose(pose_str: str) -> PoseWithCovarianceStamped:
         covariance=covariance,
     )
     return PoseWithCovarianceStamped(header=Header(frame_id="map"), pose=pose)
+
+
+def arg_to_initial_pose(pose_str: str) -> PoseWithCovarianceStamped:
+    pose_dict = pose_str_to_dict(pose_str)
+    return pose_dict_to_initial_pose(pose_dict)
 
 
 def arg_to_goal_pose(pose_str: str) -> Pose:

--- a/driving_log_replayer_v2/test/unittest/test_pose.py
+++ b/driving_log_replayer_v2/test/unittest/test_pose.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
+from driving_log_replayer_v2.pose import offset_pose_dict_forward
 from driving_log_replayer_v2.pose import pose_str_to_dict
 
 
@@ -33,3 +36,28 @@ def test_pose_str_to_dict() -> None:
     assert isinstance(pose_dict["orientation"]["y"], float)
     assert isinstance(pose_dict["orientation"]["z"], float)
     assert isinstance(pose_dict["orientation"]["w"], float)
+
+
+def test_offset_pose_dict_forward_with_identity_orientation() -> None:
+    pose_dict = pose_str_to_dict(
+        '{"position": {"x": 1, "y": 2, "z": 3}, "orientation": {"x": 0, "y": 0, "z": 0, "w": 1}}'
+    )
+
+    offset_pose = offset_pose_dict_forward(pose_dict, 0.1)
+
+    assert offset_pose["position"]["x"] == pytest.approx(1.1)
+    assert offset_pose["position"]["y"] == pytest.approx(2.0)
+    assert offset_pose["position"]["z"] == pytest.approx(3.0)
+    assert offset_pose["orientation"] == pose_dict["orientation"]
+
+
+def test_offset_pose_dict_forward_with_yaw_rotation() -> None:
+    pose_dict = pose_str_to_dict(
+        '{"position": {"x": 1, "y": 2, "z": 3}, "orientation": {"x": 0, "y": 0, "z": 0.7071067811865475, "w": 0.7071067811865476}}'
+    )
+
+    offset_pose = offset_pose_dict_forward(pose_dict, 0.1)
+
+    assert offset_pose["position"]["x"] == pytest.approx(1.0, abs=1e-9)
+    assert offset_pose["position"]["y"] == pytest.approx(2.1)
+    assert offset_pose["position"]["z"] == pytest.approx(3.0)

--- a/sample/perception_reproducer/scenario.yaml
+++ b/sample/perception_reproducer/scenario.yaml
@@ -37,6 +37,7 @@ Evaluation:
     reproduce_cool_down: 999.0 # -c, --reproduce-cool-down: cool down time for republishing (default: 80.0)
     tracked_object: false # -t, --tracked-object: publish tracked object
     search_radius: 1.5 # -r, --search-radius: search radius for searching rosbag's ego odom messages (default: 1.5)
+    move_ego_forward_after_engage_m: 0.1 # [m] after engage, perturb ego along its forward axis to let the planner start generating a moving trajectory; set 0 to disable, negative values move in the opposite direction
 
   Conditions:
     timeout_s: 80.0 # [s] scenario timeout duration, used for both engage_node and perception_reproducer_evaluator_node

--- a/sample/perception_reproducer/scenario_sample.yaml
+++ b/sample/perception_reproducer/scenario_sample.yaml
@@ -36,6 +36,7 @@ Evaluation:
     reproduce_cool_down: 999.0
     search_radius: 1.5
     tracked_object: false
+    move_ego_forward_after_engage_m: 0.1
   Conditions:
     terminated_after_fail_s: 10
     timeout_s: 119.797183508


### PR DESCRIPTION
## Types of PR

- [X] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix

## Description

In the reproducer test for the E2E branch, the diffusion planner continues to publish the stopping trajectory after engaging， which prevents the ego from starting to move. 

We need a small perturbation to get the ego moving.

Therefore, this PR resets the initial pose to 10 cm in front of the ego after engaging, tricking the diffusion planner into thinking the ego has started moving, then generating a trajectory to move.

This bug also exists in scenario_simulator_v2

[Screencast from 03-18-2026 02:42:26 PM.webm](https://github.com/user-attachments/assets/310e9669-510d-48ed-b87b-88b382c4fa91)

(Note the ego starts moving after the slight displacement in the video)

## How to review this PR

## Others
