### PR TITLE
feat(planning_control): record /vehicle/status/control_mode topic

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/planning_control.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/planning_control.py
@@ -40,6 +40,7 @@ RECORD_TOPIC = """^/tf$\
 |^/sensing/gnss/septentrio/nav_sat_fix$\
 |^/planning/ground_truth_trajectory$\
 |^/planning/reference_trajectory\
+|^/vehicle/status/control_mode$\
 """
 
 AUTOWARE_DISABLE = {


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [x] Upgrade of existing features
- [ ] Bugfix

## Description

Add `/vehicle/status/control_mode` (`autoware_vehicle_msgs/msg/ControlModeReport`) to the `RECORD_TOPIC` regex of the `planning_control` use case so it is captured into `result_bag_0.mcap` for post-process consumption.

## How to review this PR

- Verify the regex addition in `driving_log_replayer_v2/driving_log_replayer_v2/launch/planning_control.py` does not break the existing topic patterns.
- Run a `planning_control` scenario where the input rosbag contains `/vehicle/status/control_mode` and confirm the topic appears in the recorded result bag.

## Others

- The topic is only recorded if it is present in the input rosbag (or published live); ensure your `publish_profile`/playback configuration lets it through.