### PR TITLE
chore: release 3.18.1

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## Version 3.18.1
+
+Minor Tweak
+
+| Module             | Feature | Brief summary                             | Pull request                                                        | Contributor                                   |
+| ------------------ | ------- | ----------------------------------------- | ------------------------------------------------------------------- | --------------------------------------------- |
+| `perception`       | logging | disable to show metrics details           | [#359](https://github.com/tier4/driving_log_replayer_v2/issues/359) | [MasatoSaeki](https://github.com/MasatoSaeki) |
+| `planning_control` | topic   | record /vehicle/status/control_mode topic | [#358](https://github.com/tier4/driving_log_replayer_v2/issues/358) | [go-sakayori](https://github.com/go-sakayori) |
+
 ## Version 3.18.0
 
 Major changes

--- a/driving_log_replayer_v2/CHANGELOG.rst
+++ b/driving_log_replayer_v2/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog for package driving_log_replayer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* feat(perception): disable to show metrics details (`#359 <https://github.com/tier4/driving_log_replayer_v2/issues/359>`_)
+  * feat(perception): disable to show metrics details
+  * fix unnecessary changes
+  * update
+  ---------
+* feat(planning_control): record /vehicle/status/control_mode topic (`#358 <https://github.com/tier4/driving_log_replayer_v2/issues/358>`_)
+* Contributors: Go Sakayori, Masato Saeki
+
 3.18.0 (2026-05-01)
 -------------------
 * feat: support jazzy (`#354 <https://github.com/tier4/driving_log_replayer_v2/issues/354>`_)

--- a/driving_log_replayer_v2_analyzer/CHANGELOG.rst
+++ b/driving_log_replayer_v2_analyzer/CHANGELOG.rst
@@ -2,6 +2,9 @@
 Changelog for package driving_log_replayer_v2_analyzer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+
 3.18.0 (2026-05-01)
 -------------------
 

--- a/driving_log_replayer_v2_msgs/CHANGELOG.rst
+++ b/driving_log_replayer_v2_msgs/CHANGELOG.rst
@@ -2,6 +2,9 @@
 Changelog for package driving_log_replayer_v2_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+
 3.18.0 (2026-05-01)
 -------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "driving-log-replayer-v2"
-version = "3.18.0"
+version = "3.18.1"
 authors = [
   { name = "Masato Saeki", email = "masato.saeki@tier4.jp" },
   { name = "Kotaro Uetake", email = "kotaro.uetake@tier4.jp" },


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [x] Upgrade of existing features
- [ ] Bugfix

## Description

This PR release 3.18.1

ignore failing colcon-test of jazzy bacause apt package has problem.
https://repo.ros2.org/status_page/ros_jazzy_default.html?q=map_height

## How to review this PR

## Others
