### PR TITLE
fix: trajectory selector onlyt topic setting

### DIFF
--- a/driving_log_replayer_v2/config/publish_and_remap/trajectory_selector.yaml
+++ b/driving_log_replayer_v2/config/publish_and_remap/trajectory_selector.yaml
@@ -2,7 +2,7 @@
 # Note this config should be used with `disable_diffusion_planner:=true` and `enable_minimum_rule_based_planner:=false`
 publish:
   # trajectory generator outputs
-  - /planning/generator/concatenated/candidate_trajectories
+  - /planning/generator/candidate_trajectories
   - /planning/turn_indicators_cmd
   - /planning/scenario_planning/current_max_velocity
   - /planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/output/predicted_objects


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [X] Bugfix

## Description

`/planning/generator/concatenated/candidate_trajectories`が beta/v4.4で`/planning/selector/concatenated/candidate_trajectories`になりました。

直接に`/planning/generator/candidate_trajectories`を使っても良いので修正

## How to review this PR

## Others
