### PR TITLE
chore: reafactor-publish-configs

### DIFF
--- a/driving_log_replayer_v2/config/publish_and_remap/planning_control_e2e_wo_diffusion_planner.yaml
+++ b/driving_log_replayer_v2/config/publish_and_remap/planning_control_e2e_wo_diffusion_planner.yaml
@@ -8,7 +8,6 @@ publish:
   - /planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/debug/lane_marker
   - /planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/debug/linestring_marker
   - /planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/debug/route_marker
-  - /planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/debug/route_marker
   - /planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/output/predicted_objects
   - /planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/output/trajectory
   - /planning/turn_indicators_cmd

--- a/driving_log_replayer_v2/config/publish_and_remap/trajectory_selector.yaml
+++ b/driving_log_replayer_v2/config/publish_and_remap/trajectory_selector.yaml
@@ -3,9 +3,16 @@
 publish:
   # trajectory generator outputs
   - /planning/generator/candidate_trajectories
-  - /planning/turn_indicators_cmd
   - /planning/scenario_planning/current_max_velocity
+  # diffusion planner outputs
+  - /planning/planning_factors/diffusion_planner
+  - /planning/scenario_planning/lane_driving/behavior_planning/debug/traffic_signal
+  - /planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/debug/lane_marker
+  - /planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/debug/linestring_marker
+  - /planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/debug/route_marker
   - /planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/output/predicted_objects
+  - /planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/output/trajectory
+  - /planning/turn_indicators_cmd
 
   # vehicle
   - /vehicle/status/steering_status


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [X] Bugfix

## Description
The old trajectory_selector config didn't contain some topics for visualization, making debugging hard. This PR adds those topics (mainly `/planning/scenario_planning/lane_driving/behavior_planning/debug/traffic_signal`) for debugging.

## How to review this PR

## Others
