### PR TITLE
chore: refactor planning_control_e2e_wo_diffusion_planner

### DIFF
--- a/driving_log_replayer_v2/config/publish_and_remap/planning_control_e2e_wo_diffusion_planner.yaml
+++ b/driving_log_replayer_v2/config/publish_and_remap/planning_control_e2e_wo_diffusion_planner.yaml
@@ -25,7 +25,9 @@ publish:
   - /localization/kinematic_state
   - /tf
   # perception
+  - /perception/obstacle_segmentation/pointcloud
   - /perception/traffic_light_recognition/traffic_signals
+  - /perception/occupancy_grid_map/map
   - /perception/object_recognition/objects
   # planning inputs
   - /planning/mission_planning/route

--- a/driving_log_replayer_v2/config/publish_and_remap/trajectory_selector.yaml
+++ b/driving_log_replayer_v2/config/publish_and_remap/trajectory_selector.yaml
@@ -4,7 +4,7 @@ publish:
   # trajectory generator outputs
   - /planning/generator/candidate_trajectories
   - /planning/scenario_planning/current_max_velocity
-  # diffusion planner outputs
+  # diffusion planner outputs besides the trajectory
   - /planning/planning_factors/diffusion_planner
   - /planning/scenario_planning/lane_driving/behavior_planning/debug/traffic_signal
   - /planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/debug/lane_marker


### PR DESCRIPTION
Refactor planning_control_e2e_wo_diffusion_planner.yaml to allow turning on all planning nodes but diffusion planner.

## Types of PR

- [ ] New Features
- [X] Upgrade of existing features
- [ ] Bugfix

## Description

## How to review this PR

## Others
