### PR TITLE
feat: evaluate planning factor duration

### DIFF
--- a/docs/use_case/planning_control.en.md
+++ b/docs/use_case/planning_control.en.md
@@ -50,7 +50,7 @@ Normal if `/planning/planning_factors/**` meets all of the following conditions:
 - If there is a velocity condition in the scenario, the planning_factor's velocity (velocity at the control_point) is within the range specified in the scenario.
 - If there is a time_to_wall condition in the scenario, the planning_factor's time_to_wall (time to reach the control_point at current velocity) is within the range specified in the scenario.
 - If there is an acceleration_to_wall condition in the scenario, the planning_factor's acceleration_to_wall (acceleration needed to reach the control_point at current velocity) is within the range specified in the scenario.
-- If there is a duration condition in the scenario, the consecutive duration while factors exist in the topic is within the range specified in the scenario. The first frame is 0.1s, then 0.1s plus timestamp delta from session start. The session resets when `factors` is empty or no factor frame arrives for 0.5s. Duration session tracking only requires factor presence and is independent from other sub-conditions.
+- If there is a duration condition in the scenario, the duration session advances only on frames where all other sub-conditions (area/behavior/distance/velocity/time_to_wall/acceleration_to_wall) judge successfully, and the consecutive duration is checked against the specified range. The first valid frame is 0.1s, then 0.1s plus timestamp delta from session start. The session resets when `factors` is empty or no valid frame arrives for 0.5s since the last valid frame. Duration is judged after other sub-conditions and before judgement inversion.
 
 #### PlanningFactor Normal(judgement: negative)
 
@@ -62,7 +62,7 @@ Normal if `/planning/planning_factors/**` does not meet any of the following con
 - If there is a velocity condition in the scenario, the planning_factor's velocity (velocity at the control_point) is within the range specified in the scenario.
 - If there is a time_to_wall condition in the scenario, the planning_factor's time_to_wall (time to reach the control_point at current velocity) is within the range specified in the scenario.
 - If there is an acceleration_to_wall condition in the scenario, the planning_factor's acceleration_to_wall (acceleration needed to reach the control_point at current velocity) is within the range specified in the scenario.
-- If there is a duration condition in the scenario, the consecutive duration while factors exist in the topic is within the range specified in the scenario. The first frame is 0.1s, then 0.1s plus timestamp delta from session start. The session resets when `factors` is empty or no factor frame arrives for 0.5s. Duration session tracking only requires factor presence and is independent from other sub-conditions.
+- If there is a duration condition in the scenario, the duration session advances only on frames where all other sub-conditions (area/behavior/distance/velocity/time_to_wall/acceleration_to_wall) judge successfully, and the consecutive duration is checked against the specified range. The first valid frame is 0.1s, then 0.1s plus timestamp delta from session start. The session resets when `factors` is empty or no valid frame arrives for 0.5s since the last valid frame. Duration is judged after other sub-conditions and before judgement inversion.
 
 #### PlanningFactor Error
 

--- a/docs/use_case/planning_control.en.md
+++ b/docs/use_case/planning_control.en.md
@@ -50,7 +50,7 @@ Normal if `/planning/planning_factors/**` meets all of the following conditions:
 - If there is a velocity condition in the scenario, the planning_factor's velocity (velocity at the control_point) is within the range specified in the scenario.
 - If there is a time_to_wall condition in the scenario, the planning_factor's time_to_wall (time to reach the control_point at current velocity) is within the range specified in the scenario.
 - If there is an acceleration_to_wall condition in the scenario, the planning_factor's acceleration_to_wall (acceleration needed to reach the control_point at current velocity) is within the range specified in the scenario.
-- If there is a duration condition in the scenario, the consecutive duration while factors exist in the topic is within the range specified in the scenario. The first frame is 0.1s, then timestamp delta from session start. The session resets when `factors` is empty or no factor frame arrives for 0.5s. Duration session tracking only requires factor presence and is independent from other sub-conditions.
+- If there is a duration condition in the scenario, the consecutive duration while factors exist in the topic is within the range specified in the scenario. The first frame is 0.1s, then 0.1s plus timestamp delta from session start. The session resets when `factors` is empty or no factor frame arrives for 0.5s. Duration session tracking only requires factor presence and is independent from other sub-conditions.
 
 #### PlanningFactor Normal(judgement: negative)
 
@@ -62,7 +62,7 @@ Normal if `/planning/planning_factors/**` does not meet any of the following con
 - If there is a velocity condition in the scenario, the planning_factor's velocity (velocity at the control_point) is within the range specified in the scenario.
 - If there is a time_to_wall condition in the scenario, the planning_factor's time_to_wall (time to reach the control_point at current velocity) is within the range specified in the scenario.
 - If there is an acceleration_to_wall condition in the scenario, the planning_factor's acceleration_to_wall (acceleration needed to reach the control_point at current velocity) is within the range specified in the scenario.
-- If there is a duration condition in the scenario, the consecutive duration while factors exist in the topic is within the range specified in the scenario. The first frame is 0.1s, then timestamp delta from session start. The session resets when `factors` is empty or no factor frame arrives for 0.5s. Duration session tracking only requires factor presence and is independent from other sub-conditions.
+- If there is a duration condition in the scenario, the consecutive duration while factors exist in the topic is within the range specified in the scenario. The first frame is 0.1s, then 0.1s plus timestamp delta from session start. The session resets when `factors` is empty or no factor frame arrives for 0.5s. Duration session tracking only requires factor presence and is independent from other sub-conditions.
 
 #### PlanningFactor Error
 

--- a/docs/use_case/planning_control.en.md
+++ b/docs/use_case/planning_control.en.md
@@ -50,6 +50,7 @@ Normal if `/planning/planning_factors/**` meets all of the following conditions:
 - If there is a velocity condition in the scenario, the planning_factor's velocity (velocity at the control_point) is within the range specified in the scenario.
 - If there is a time_to_wall condition in the scenario, the planning_factor's time_to_wall (time to reach the control_point at current velocity) is within the range specified in the scenario.
 - If there is an acceleration_to_wall condition in the scenario, the planning_factor's acceleration_to_wall (acceleration needed to reach the control_point at current velocity) is within the range specified in the scenario.
+- If there is a duration condition in the scenario, the consecutive duration while factors exist in the topic is within the range specified in the scenario. The first frame is 0.1s, then timestamp delta from session start. The session resets when `factors` is empty or no factor frame arrives for 0.5s. Duration session tracking only requires factor presence and is independent from other sub-conditions.
 
 #### PlanningFactor Normal(judgement: negative)
 
@@ -61,6 +62,7 @@ Normal if `/planning/planning_factors/**` does not meet any of the following con
 - If there is a velocity condition in the scenario, the planning_factor's velocity (velocity at the control_point) is within the range specified in the scenario.
 - If there is a time_to_wall condition in the scenario, the planning_factor's time_to_wall (time to reach the control_point at current velocity) is within the range specified in the scenario.
 - If there is an acceleration_to_wall condition in the scenario, the planning_factor's acceleration_to_wall (acceleration needed to reach the control_point at current velocity) is within the range specified in the scenario.
+- If there is a duration condition in the scenario, the consecutive duration while factors exist in the topic is within the range specified in the scenario. The first frame is 0.1s, then timestamp delta from session start. The session resets when `factors` is empty or no factor frame arrives for 0.5s. Duration session tracking only requires factor presence and is independent from other sub-conditions.
 
 #### PlanningFactor Error
 

--- a/docs/use_case/planning_control.ja.md
+++ b/docs/use_case/planning_control.ja.md
@@ -56,7 +56,7 @@ Metric正常の条件を満たさないとき
 - シナリオにvelocity条件がある場合、planning_factorのvelocity(control_pointでの速度)がシナリオで指定した範囲に入っている。
 - シナリオにtime_to_wall条件がある場合、planning_factorのtime_to_wall(現在の速度でcontrol_pointに到達するまでの時間)がシナリオで指定した範囲に入っている。
 - シナリオにacceleration_to_wall条件がある場合、planning_factorのacceleration_to_wall(現在の速度でcontrol_pointに到達するために必要な加速度)がシナリオで指定した範囲に入っている。
-- シナリオにduration条件がある場合、topic内にfactorが存在し続けている連続時間がシナリオで指定した範囲に入っている。初回frameは0.1s、以降は0.1sにsession開始時刻からのtimestamp差分を加算。`factors`が空、または0.5s以上factor frameが来ない場合はsessionが中断される。durationのframe判定はfactorの有無のみで、他の子条件とは独立してsessionを進める。
+- シナリオにduration条件がある場合、他の子条件（area/behavior/distance/velocity/time_to_wall/acceleration_to_wall）がすべてjudge成功したframeのみsessionを進め、連続時間がシナリオで指定した範囲に入っているか判定する。初回valid frameは0.1s、以降は0.1sにsession開始時刻からのtimestamp差分を加算。`factors`が空、またはlast valid frameから0.5s以上valid frameが来ない場合はsessionが中断される。duration判定は他の子条件judgeの後、judgement反転の前に行う。
 
 #### PlanningFactor正常(judgement: negative)
 
@@ -68,7 +68,7 @@ Metric正常の条件を満たさないとき
 - シナリオにvelocity条件がある場合、planning_factorのvelocity(control_pointでの速度)がシナリオで指定した範囲に入っている。
 - シナリオにtime_to_wall条件がある場合、planning_factorのtime_to_wall(現在の速度でcontrol_pointに到達するまでの時間)がシナリオで指定した範囲に入っている。
 - シナリオにacceleration_to_wall条件がある場合、planning_factorのacceleration_to_wall(現在の速度でcontrol_pointに到達するために必要な加速度)がシナリオで指定した範囲に入っている。
-- シナリオにduration条件がある場合、topic内にfactorが存在し続けている連続時間がシナリオで指定した範囲に入っている。初回frameは0.1s、以降は0.1sにsession開始時刻からのtimestamp差分を加算。`factors`が空、または0.5s以上factor frameが来ない場合はsessionが中断される。durationのframe判定はfactorの有無のみで、他の子条件とは独立してsessionを進める。
+- シナリオにduration条件がある場合、他の子条件（area/behavior/distance/velocity/time_to_wall/acceleration_to_wall）がすべてjudge成功したframeのみsessionを進め、連続時間がシナリオで指定した範囲に入っているか判定する。初回valid frameは0.1s、以降は0.1sにsession開始時刻からのtimestamp差分を加算。`factors`が空、またはlast valid frameから0.5s以上valid frameが来ない場合はsessionが中断される。duration判定は他の子条件judgeの後、judgement反転の前に行う。
 
 #### PlanningFactor異常
 

--- a/docs/use_case/planning_control.ja.md
+++ b/docs/use_case/planning_control.ja.md
@@ -56,6 +56,7 @@ Metric正常の条件を満たさないとき
 - シナリオにvelocity条件がある場合、planning_factorのvelocity(control_pointでの速度)がシナリオで指定した範囲に入っている。
 - シナリオにtime_to_wall条件がある場合、planning_factorのtime_to_wall(現在の速度でcontrol_pointに到達するまでの時間)がシナリオで指定した範囲に入っている。
 - シナリオにacceleration_to_wall条件がある場合、planning_factorのacceleration_to_wall(現在の速度でcontrol_pointに到達するために必要な加速度)がシナリオで指定した範囲に入っている。
+- シナリオにduration条件がある場合、topic内にfactorが存在し続けている連続時間がシナリオで指定した範囲に入っている。初回frameは0.1s、以降はsession開始時刻からのtimestamp差分。`factors`が空、または0.5s以上factor frameが来ない場合はsessionが中断される。durationのframe判定はfactorの有無のみで、他の子条件とは独立してsessionを進める。
 
 #### PlanningFactor正常(judgement: negative)
 
@@ -67,6 +68,7 @@ Metric正常の条件を満たさないとき
 - シナリオにvelocity条件がある場合、planning_factorのvelocity(control_pointでの速度)がシナリオで指定した範囲に入っている。
 - シナリオにtime_to_wall条件がある場合、planning_factorのtime_to_wall(現在の速度でcontrol_pointに到達するまでの時間)がシナリオで指定した範囲に入っている。
 - シナリオにacceleration_to_wall条件がある場合、planning_factorのacceleration_to_wall(現在の速度でcontrol_pointに到達するために必要な加速度)がシナリオで指定した範囲に入っている。
+- シナリオにduration条件がある場合、topic内にfactorが存在し続けている連続時間がシナリオで指定した範囲に入っている。初回frameは0.1s、以降はsession開始時刻からのtimestamp差分。`factors`が空、または0.5s以上factor frameが来ない場合はsessionが中断される。durationのframe判定はfactorの有無のみで、他の子条件とは独立してsessionを進める。
 
 #### PlanningFactor異常
 

--- a/docs/use_case/planning_control.ja.md
+++ b/docs/use_case/planning_control.ja.md
@@ -56,7 +56,7 @@ Metric正常の条件を満たさないとき
 - シナリオにvelocity条件がある場合、planning_factorのvelocity(control_pointでの速度)がシナリオで指定した範囲に入っている。
 - シナリオにtime_to_wall条件がある場合、planning_factorのtime_to_wall(現在の速度でcontrol_pointに到達するまでの時間)がシナリオで指定した範囲に入っている。
 - シナリオにacceleration_to_wall条件がある場合、planning_factorのacceleration_to_wall(現在の速度でcontrol_pointに到達するために必要な加速度)がシナリオで指定した範囲に入っている。
-- シナリオにduration条件がある場合、topic内にfactorが存在し続けている連続時間がシナリオで指定した範囲に入っている。初回frameは0.1s、以降はsession開始時刻からのtimestamp差分。`factors`が空、または0.5s以上factor frameが来ない場合はsessionが中断される。durationのframe判定はfactorの有無のみで、他の子条件とは独立してsessionを進める。
+- シナリオにduration条件がある場合、topic内にfactorが存在し続けている連続時間がシナリオで指定した範囲に入っている。初回frameは0.1s、以降は0.1sにsession開始時刻からのtimestamp差分を加算。`factors`が空、または0.5s以上factor frameが来ない場合はsessionが中断される。durationのframe判定はfactorの有無のみで、他の子条件とは独立してsessionを進める。
 
 #### PlanningFactor正常(judgement: negative)
 
@@ -68,7 +68,7 @@ Metric正常の条件を満たさないとき
 - シナリオにvelocity条件がある場合、planning_factorのvelocity(control_pointでの速度)がシナリオで指定した範囲に入っている。
 - シナリオにtime_to_wall条件がある場合、planning_factorのtime_to_wall(現在の速度でcontrol_pointに到達するまでの時間)がシナリオで指定した範囲に入っている。
 - シナリオにacceleration_to_wall条件がある場合、planning_factorのacceleration_to_wall(現在の速度でcontrol_pointに到達するために必要な加速度)がシナリオで指定した範囲に入っている。
-- シナリオにduration条件がある場合、topic内にfactorが存在し続けている連続時間がシナリオで指定した範囲に入っている。初回frameは0.1s、以降はsession開始時刻からのtimestamp差分。`factors`が空、または0.5s以上factor frameが来ない場合はsessionが中断される。durationのframe判定はfactorの有無のみで、他の子条件とは独立してsessionを進める。
+- シナリオにduration条件がある場合、topic内にfactorが存在し続けている連続時間がシナリオで指定した範囲に入っている。初回frameは0.1s、以降は0.1sにsession開始時刻からのtimestamp差分を加算。`factors`が空、または0.5s以上factor frameが来ない場合はsessionが中断される。durationのframe判定はfactorの有無のみで、他の子条件とは独立してsessionを進める。
 
 #### PlanningFactor異常
 

--- a/driving_log_replayer_v2/driving_log_replayer_v2/planning_control.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/planning_control.py
@@ -297,7 +297,7 @@ class PlanningFactor(EvaluationItem):
             self.duration_session_start_stamp = current_stamp
             duration = self.DURATION_INITIAL_S
         else:
-            duration = current_stamp - self.duration_session_start_stamp
+            duration = self.DURATION_INITIAL_S + (current_stamp - self.duration_session_start_stamp)
         self.duration_last_frame_stamp = current_stamp
         return duration
 

--- a/driving_log_replayer_v2/driving_log_replayer_v2/planning_control.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/planning_control.py
@@ -143,6 +143,7 @@ class PlanningFactorCondition(BaseModel):
     acceleration_to_wall: MinMax | None = (
         None  # needed acceleration to the next control point with the current velocity
     )
+    duration: MinMax | None = None  # consecutive duration while factors exist in topic [s]
     judgement: Literal["positive", "negative"]  # positive or negative
 
 
@@ -153,7 +154,9 @@ class Conditions(BaseModel):
 
 class Evaluation(BaseModel):
     UseCaseName: Literal["planning_control"]
-    UseCaseFormatVersion: Literal["2.0.0", "2.1.0", "2.2.0", "2.3.0", "2.4.0", "2.5.0", "2.6.0"]
+    UseCaseFormatVersion: Literal[
+        "2.0.0", "2.1.0", "2.2.0", "2.3.0", "2.4.0", "2.5.0", "2.6.0", "2.7.0"
+    ]
     Conditions: Conditions
     Datasets: list[dict]
 
@@ -262,6 +265,9 @@ class MetricResult(ResultBase):
 
 @dataclass
 class PlanningFactor(EvaluationItem):
+    DURATION_INITIAL_S = 0.1
+    DURATION_GAP_STOP_S = 0.5
+
     def __post_init__(self) -> None:
         self.condition: PlanningFactorCondition
         self.success = self.condition.judgement == "negative"
@@ -272,6 +278,28 @@ class PlanningFactor(EvaluationItem):
         self.stop_vel_thr = 0.13889  # 0.5 [km/h] margin to consider as stop
         self.reach_wall_vel_margin = 0.55556  # 2[km/h] margin to consider as reaching the wall
         self.reach_wall_distance_margin = 0.2  # [m] margin to consider as reaching the wall
+        self.duration_session_start_stamp: float | None = None
+        self.duration_last_frame_stamp: float | None = None
+
+    def _reset_duration_session(self) -> None:
+        self.duration_session_start_stamp = None
+        self.duration_last_frame_stamp = None
+
+    def _check_duration_gap(self, current_stamp: float) -> None:
+        if (
+            self.duration_last_frame_stamp is not None
+            and current_stamp - self.duration_last_frame_stamp > self.DURATION_GAP_STOP_S
+        ):
+            self._reset_duration_session()
+
+    def _update_duration_session(self, current_stamp: float) -> float:
+        if self.duration_session_start_stamp is None:
+            self.duration_session_start_stamp = current_stamp
+            duration = self.DURATION_INITIAL_S
+        else:
+            duration = current_stamp - self.duration_session_start_stamp
+        self.duration_last_frame_stamp = current_stamp
+        return duration
 
     def set_frame(  # noqa: C901, PLR0915, PLR0912
         self, msg: PlanningFactorArray, latest_kinematic_state: Odometry | None
@@ -281,13 +309,18 @@ class PlanningFactor(EvaluationItem):
             return None
 
         self.total += 1
+        current_stamp = stamp_to_float(msg.header.stamp)
 
         if len(msg.factors) == 0:
+            self._reset_duration_session()
             condition_met = self.condition.judgement == "negative"
             info_dict = {
                 "Factor_0": "NO_FACTOR",
             }
         else:
+            self._check_duration_gap(current_stamp)
+            session_duration = self._update_duration_session(current_stamp)
+
             condition_met = False
             info_dict = {}
 
@@ -365,6 +398,11 @@ class PlanningFactor(EvaluationItem):
                     info_dict_per_factor.update(info_dict_acceleration_to_wall)
                     condition_met_per_factor &= acceleration_to_wall_met
 
+                if self.condition.duration is not None:
+                    duration_met, info_dict_duration = self.judge_duration(session_duration)
+                    info_dict_per_factor.update(info_dict_duration)
+                    condition_met_per_factor &= duration_met
+
                 condition_met_per_factor ^= self.condition.judgement == "negative"
 
                 info_dict[f"Factor_{i}"] = info_dict_per_factor
@@ -437,6 +475,12 @@ class PlanningFactor(EvaluationItem):
             "TimeToWall": time_to_wall,
         }
         return self.condition.time_to_wall.match_condition(time_to_wall), info_dict
+
+    def judge_duration(self, duration: float) -> tuple[bool, dict]:
+        info_dict = {
+            "Duration": duration,
+        }
+        return self.condition.duration.match_condition(duration), info_dict
 
     def judge_acceleration_to_wall(
         self, factor_distance: float, current_velocity: float, factor_velocity: float

--- a/driving_log_replayer_v2/driving_log_replayer_v2/planning_control.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/planning_control.py
@@ -318,11 +318,9 @@ class PlanningFactor(EvaluationItem):
                 "Factor_0": "NO_FACTOR",
             }
         else:
-            self._check_duration_gap(current_stamp)
-            session_duration = self._update_duration_session(current_stamp)
-
             condition_met = False
             info_dict = {}
+            session_duration: float | None = None
 
             current_velocity = (
                 latest_kinematic_state.twist.twist.linear.x
@@ -398,7 +396,10 @@ class PlanningFactor(EvaluationItem):
                     info_dict_per_factor.update(info_dict_acceleration_to_wall)
                     condition_met_per_factor &= acceleration_to_wall_met
 
-                if self.condition.duration is not None:
+                if self.condition.duration is not None and condition_met_per_factor:
+                    if session_duration is None:
+                        self._check_duration_gap(current_stamp)
+                        session_duration = self._update_duration_session(current_stamp)
                     duration_met, info_dict_duration = self.judge_duration(session_duration)
                     info_dict_per_factor.update(info_dict_duration)
                     condition_met_per_factor &= duration_met

--- a/driving_log_replayer_v2/test/unittest/test_planning_control.py
+++ b/driving_log_replayer_v2/test/unittest/test_planning_control.py
@@ -236,7 +236,7 @@ def test_planning_factor_duration_accumulates() -> None:
     )
 
     assert result is not None
-    assert result["Info"]["Factor_0"]["Duration"] == pytest.approx(0.3)
+    assert result["Info"]["Factor_0"]["Duration"] == pytest.approx(0.4)
 
 
 def test_planning_factor_duration_empty_factors_resets_session() -> None:
@@ -288,7 +288,7 @@ def test_planning_factor_duration_advances_without_behavior_match() -> None:
 
     assert result is not None
     assert result["Result"]["Frame"] == "Fail"
-    assert result["Info"]["Factor_0"]["Duration"] == pytest.approx(0.4)
+    assert result["Info"]["Factor_0"]["Duration"] == pytest.approx(0.5)
 
 
 def test_planning_factor_duration_out_of_range() -> None:

--- a/driving_log_replayer_v2/test/unittest/test_planning_control.py
+++ b/driving_log_replayer_v2/test/unittest/test_planning_control.py
@@ -227,7 +227,10 @@ def test_planning_factor_duration_first_frame() -> None:
 
 
 def test_planning_factor_duration_accumulates() -> None:
-    condition = create_planning_factor_condition(duration=MinMax(min=0.0, max=10.0))
+    condition = create_planning_factor_condition(
+        behavior=["STOP"],
+        duration=MinMax(min=0.0, max=10.0),
+    )
     evaluation_item = PlanningFactor(name="pf_0", condition=condition)
 
     evaluation_item.set_frame(create_planning_factor_array_msg(stamp_sec=1), None)
@@ -240,7 +243,10 @@ def test_planning_factor_duration_accumulates() -> None:
 
 
 def test_planning_factor_duration_empty_factors_resets_session() -> None:
-    condition = create_planning_factor_condition(duration=MinMax(min=0.1, max=10.0))
+    condition = create_planning_factor_condition(
+        behavior=["STOP"],
+        duration=MinMax(min=0.1, max=10.0),
+    )
     evaluation_item = PlanningFactor(name="pf_0", condition=condition)
 
     evaluation_item.set_frame(
@@ -256,7 +262,10 @@ def test_planning_factor_duration_empty_factors_resets_session() -> None:
 
 
 def test_planning_factor_duration_gap_resets_session() -> None:
-    condition = create_planning_factor_condition(duration=MinMax(min=0.1, max=10.0))
+    condition = create_planning_factor_condition(
+        behavior=["STOP"],
+        duration=MinMax(min=0.1, max=10.0),
+    )
     evaluation_item = PlanningFactor(name="pf_0", condition=condition)
 
     evaluation_item.set_frame(create_planning_factor_array_msg(stamp_sec=1), None)
@@ -266,17 +275,22 @@ def test_planning_factor_duration_gap_resets_session() -> None:
     assert result["Info"]["Factor_0"]["Duration"] == pytest.approx(0.1)
 
 
-def test_planning_factor_duration_advances_without_behavior_match() -> None:
+def test_planning_factor_duration_does_not_advance_without_behavior_match() -> None:
     condition = create_planning_factor_condition(
         behavior=["STOP"],
         duration=MinMax(min=0.0, max=10.0),
     )
     evaluation_item = PlanningFactor(name="pf_0", condition=condition)
 
-    evaluation_item.set_frame(
+    result = evaluation_item.set_frame(
         create_planning_factor_array_msg(stamp_sec=1, behavior=PlanningFactorMsg.SLOW_DOWN),
         None,
     )
+
+    assert result is not None
+    assert result["Result"]["Frame"] == "Fail"
+    assert "Duration" not in result["Info"]["Factor_0"]
+
     result = evaluation_item.set_frame(
         create_planning_factor_array_msg(
             stamp_sec=1,
@@ -287,8 +301,32 @@ def test_planning_factor_duration_advances_without_behavior_match() -> None:
     )
 
     assert result is not None
-    assert result["Result"]["Frame"] == "Fail"
-    assert result["Info"]["Factor_0"]["Duration"] == pytest.approx(0.5)
+    assert "Duration" not in result["Info"]["Factor_0"]
+
+
+def test_planning_factor_duration_gap_from_last_valid_frame() -> None:
+    condition = create_planning_factor_condition(
+        behavior=["STOP"],
+        duration=MinMax(min=0.1, max=10.0),
+    )
+    evaluation_item = PlanningFactor(name="pf_0", condition=condition)
+
+    evaluation_item.set_frame(create_planning_factor_array_msg(stamp_sec=1), None)
+    evaluation_item.set_frame(
+        create_planning_factor_array_msg(
+            stamp_sec=1,
+            stamp_nanosec=200_000_000,
+            behavior=PlanningFactorMsg.SLOW_DOWN,
+        ),
+        None,
+    )
+    result = evaluation_item.set_frame(
+        create_planning_factor_array_msg(stamp_sec=1, stamp_nanosec=700_000_000),
+        None,
+    )
+
+    assert result is not None
+    assert result["Info"]["Factor_0"]["Duration"] == pytest.approx(0.1)
 
 
 def test_planning_factor_duration_out_of_range() -> None:

--- a/driving_log_replayer_v2/test/unittest/test_planning_control.py
+++ b/driving_log_replayer_v2/test/unittest/test_planning_control.py
@@ -14,9 +14,16 @@
 
 from typing import Literal
 
+from autoware_internal_planning_msgs.msg import ControlPoint
+from autoware_internal_planning_msgs.msg import PlanningFactor as PlanningFactorMsg
+from autoware_internal_planning_msgs.msg import PlanningFactorArray
 from builtin_interfaces.msg import Time
+from geometry_msgs.msg import Point
+from geometry_msgs.msg import Pose
+from geometry_msgs.msg import Quaternion
 from pydantic import ValidationError
 import pytest
+from std_msgs.msg import Header
 from tier4_metric_msgs.msg import Metric as MetricMsg
 from tier4_metric_msgs.msg import MetricArray
 
@@ -24,6 +31,8 @@ from driving_log_replayer_v2.planning_control import Metric
 from driving_log_replayer_v2.planning_control import MetricCondition
 from driving_log_replayer_v2.planning_control import MinMax
 from driving_log_replayer_v2.planning_control import PlanningControlScenario
+from driving_log_replayer_v2.planning_control import PlanningFactor
+from driving_log_replayer_v2.planning_control import PlanningFactorCondition
 from driving_log_replayer_v2.scenario import load_sample_scenario
 
 
@@ -159,3 +168,148 @@ def test_metrics_fail_all_of() -> None:
         "Result": {"Total": "Fail", "Frame": "Fail"},
         "Info": {"MetricName": "acceleration", "MetricValue": 2.0},
     }
+
+
+def create_planning_factor_condition(
+    *,
+    behavior: list[str] | None = None,
+    duration: MinMax | None = None,
+    judgement: Literal["positive", "negative"] = "positive",
+) -> PlanningFactorCondition:
+    return PlanningFactorCondition(
+        condition_name="pf_check",
+        topic="/planning/planning_factors/obstacle_stop",
+        time={"start": 0.0, "end": 100.0},
+        condition_type="any_of",
+        behavior=behavior,
+        duration=duration,
+        judgement=judgement,
+    )
+
+
+def create_planning_factor_array_msg(
+    *,
+    stamp_sec: int = 1,
+    stamp_nanosec: int = 0,
+    behavior: int = PlanningFactorMsg.STOP,
+    factor_count: int = 1,
+) -> PlanningFactorArray:
+    control_point = ControlPoint()
+    control_point.distance = 10.0
+    control_point.velocity = 20.0
+    control_point.pose = Pose(
+        position=Point(x=0.0, y=0.0, z=0.0),
+        orientation=Quaternion(),
+    )
+
+    factors = []
+    for _ in range(factor_count):
+        factor = PlanningFactorMsg()
+        factor.behavior = behavior
+        factor.control_points = [control_point]
+        factors.append(factor)
+
+    msg = PlanningFactorArray()
+    msg.header = Header(stamp=Time(sec=stamp_sec, nanosec=stamp_nanosec))
+    msg.factors = factors
+    return msg
+
+
+def test_planning_factor_duration_first_frame() -> None:
+    condition = create_planning_factor_condition(duration=MinMax(min=0.1, max=10.0))
+    evaluation_item = PlanningFactor(name="pf_0", condition=condition)
+
+    result = evaluation_item.set_frame(create_planning_factor_array_msg(), None)
+
+    assert result is not None
+    assert result["Result"]["Frame"] == "Success"
+    assert result["Info"]["Factor_0"]["Duration"] == pytest.approx(0.1)
+
+
+def test_planning_factor_duration_accumulates() -> None:
+    condition = create_planning_factor_condition(duration=MinMax(min=0.0, max=10.0))
+    evaluation_item = PlanningFactor(name="pf_0", condition=condition)
+
+    evaluation_item.set_frame(create_planning_factor_array_msg(stamp_sec=1), None)
+    result = evaluation_item.set_frame(
+        create_planning_factor_array_msg(stamp_sec=1, stamp_nanosec=300_000_000), None
+    )
+
+    assert result is not None
+    assert result["Info"]["Factor_0"]["Duration"] == pytest.approx(0.3)
+
+
+def test_planning_factor_duration_empty_factors_resets_session() -> None:
+    condition = create_planning_factor_condition(duration=MinMax(min=0.1, max=10.0))
+    evaluation_item = PlanningFactor(name="pf_0", condition=condition)
+
+    evaluation_item.set_frame(
+        create_planning_factor_array_msg(stamp_sec=1, stamp_nanosec=500_000_000), None
+    )
+    empty_msg = create_planning_factor_array_msg(stamp_sec=2)
+    empty_msg.factors = []
+    evaluation_item.set_frame(empty_msg, None)
+    result = evaluation_item.set_frame(create_planning_factor_array_msg(stamp_sec=3), None)
+
+    assert result is not None
+    assert result["Info"]["Factor_0"]["Duration"] == pytest.approx(0.1)
+
+
+def test_planning_factor_duration_gap_resets_session() -> None:
+    condition = create_planning_factor_condition(duration=MinMax(min=0.1, max=10.0))
+    evaluation_item = PlanningFactor(name="pf_0", condition=condition)
+
+    evaluation_item.set_frame(create_planning_factor_array_msg(stamp_sec=1), None)
+    result = evaluation_item.set_frame(create_planning_factor_array_msg(stamp_sec=2), None)
+
+    assert result is not None
+    assert result["Info"]["Factor_0"]["Duration"] == pytest.approx(0.1)
+
+
+def test_planning_factor_duration_advances_without_behavior_match() -> None:
+    condition = create_planning_factor_condition(
+        behavior=["STOP"],
+        duration=MinMax(min=0.0, max=10.0),
+    )
+    evaluation_item = PlanningFactor(name="pf_0", condition=condition)
+
+    evaluation_item.set_frame(
+        create_planning_factor_array_msg(stamp_sec=1, behavior=PlanningFactorMsg.SLOW_DOWN),
+        None,
+    )
+    result = evaluation_item.set_frame(
+        create_planning_factor_array_msg(
+            stamp_sec=1,
+            stamp_nanosec=400_000_000,
+            behavior=PlanningFactorMsg.SLOW_DOWN,
+        ),
+        None,
+    )
+
+    assert result is not None
+    assert result["Result"]["Frame"] == "Fail"
+    assert result["Info"]["Factor_0"]["Duration"] == pytest.approx(0.4)
+
+
+def test_planning_factor_duration_out_of_range() -> None:
+    condition = create_planning_factor_condition(duration=MinMax(min=1.0, max=10.0))
+    evaluation_item = PlanningFactor(name="pf_0", condition=condition)
+
+    result = evaluation_item.set_frame(create_planning_factor_array_msg(), None)
+
+    assert result is not None
+    assert result["Result"]["Frame"] == "Fail"
+    assert result["Info"]["Factor_0"]["Duration"] == pytest.approx(0.1)
+
+
+def test_planning_factor_duration_negative_judgement() -> None:
+    condition = create_planning_factor_condition(
+        duration=MinMax(min=1.0, max=10.0),
+        judgement="negative",
+    )
+    evaluation_item = PlanningFactor(name="pf_0", condition=condition)
+
+    result = evaluation_item.set_frame(create_planning_factor_array_msg(), None)
+
+    assert result is not None
+    assert result["Result"]["Frame"] == "Success"

--- a/sample/planning_control/scenario_planning_factor_only.yaml
+++ b/sample/planning_control/scenario_planning_factor_only.yaml
@@ -20,5 +20,5 @@ Evaluation:
         velocity: { min: 10.0, max: 40.0 } # [m/s] Specify the velocity to be judged. You can set velocity to null to ignore velocity condition.
         time_to_wall: { min: 0.0 } # [s] Specify the time to the next control point of this planning factor to be judged. You can set time_to_wall to null to ignore time_to_wall condition.
         acceleration_to_wall: { min: -3.0 } # [m/s^2] Specify the acceleration to the next control point of this planning factor to be judged. You can set acceleration_to_wall to null to ignore acceleration_to_wall condition.
-        duration: { min: 0.2 } # [s] Consecutive duration while factors exist in topic. First frame is 0.1s, then timestamp delta from session start. Session resets when factors is empty or gap exceeds 0.5s. You can set duration to null to ignore duration condition.
+        duration: { min: 0.2 } # [s] Consecutive duration while factors exist in topic. First frame is 0.1s, then 0.1s plus timestamp delta from session start. Session resets when factors is empty or gap exceeds 0.5s. You can set duration to null to ignore duration condition.
         judgement: positive # positive or negative

--- a/sample/planning_control/scenario_planning_factor_only.yaml
+++ b/sample/planning_control/scenario_planning_factor_only.yaml
@@ -20,4 +20,5 @@ Evaluation:
         velocity: { min: 10.0, max: 40.0 } # [m/s] Specify the velocity to be judged. You can set velocity to null to ignore velocity condition.
         time_to_wall: { min: 0.0 } # [s] Specify the time to the next control point of this planning factor to be judged. You can set time_to_wall to null to ignore time_to_wall condition.
         acceleration_to_wall: { min: -3.0 } # [m/s^2] Specify the acceleration to the next control point of this planning factor to be judged. You can set acceleration_to_wall to null to ignore acceleration_to_wall condition.
+        duration: { min: 0.2 } # [s] Consecutive duration while factors exist in topic. First frame is 0.1s, then timestamp delta from session start. Session resets when factors is empty or gap exceeds 0.5s. You can set duration to null to ignore duration condition.
         judgement: positive # positive or negative

--- a/sample/planning_control/scenario_planning_factor_only.yaml
+++ b/sample/planning_control/scenario_planning_factor_only.yaml
@@ -20,5 +20,5 @@ Evaluation:
         velocity: { min: 10.0, max: 40.0 } # [m/s] Specify the velocity to be judged. You can set velocity to null to ignore velocity condition.
         time_to_wall: { min: 0.0 } # [s] Specify the time to the next control point of this planning factor to be judged. You can set time_to_wall to null to ignore time_to_wall condition.
         acceleration_to_wall: { min: -3.0 } # [m/s^2] Specify the acceleration to the next control point of this planning factor to be judged. You can set acceleration_to_wall to null to ignore acceleration_to_wall condition.
-        duration: { min: 0.2 } # [s] Consecutive duration while factors exist in topic. First frame is 0.1s, then 0.1s plus timestamp delta from session start. Session resets when factors is empty or gap exceeds 0.5s. You can set duration to null to ignore duration condition.
+        duration: { min: 0.2 } # [s] Consecutive duration while other sub-conditions judge successfully. First valid frame is 0.1s, then 0.1s plus timestamp delta from session start. Session resets when factors is empty or no valid frame for 0.5s since last valid frame. You can set duration to null to ignore duration condition.
         judgement: positive # positive or negative


### PR DESCRIPTION
## Types of PR

- [X] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix

## Description
Add a new judgment condition to check the keep duration for the planning factor.

```
        duration: { min: 0.2 } # [s] Consecutive duration while other sub-conditions judge successfully. First valid frame is 0.1s, then 0.1s plus timestamp delta from session start. Session resets when factors are empty or there is no valid frame for 0.5s since the last valid frame. You can set the duration to null to ignore the duration condition.
```

<img width="385" height="248" alt="image" src="https://github.com/user-attachments/assets/db8c1329-64ec-4390-96db-aea10eac5196" />


## How to review this PR

## Others
