### PR TITLE
fix(2d_detector): update tensorrt_yolox remaping param

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/camera_2d_detector.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/camera_2d_detector.py
@@ -56,9 +56,11 @@ def create_2d_detector_container(
     # YOLOX node
     yolox_package_dir = Path(get_package_share_directory("autoware_tensorrt_yolox"))
     yolox_param_path = Path(yolox_package_dir, "config", yolox_param_file).as_posix()
-    
+
     # cspell:ignore semseg
-    roi_to_semantic_segmentation_remap_path = Path(yolox_package_dir, "config", "roi_to_semseg_label_remap.csv").as_posix()
+    roi_to_semantic_segmentation_remap_path = Path(
+        yolox_package_dir, "config", "roi_to_semseg_label_remap.csv"
+    ).as_posix()
     yolox_params = {
         "model_path": yolox_model_path,
         "label_path": yolox_label_path,

--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/camera_2d_detector.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/camera_2d_detector.py
@@ -56,6 +56,8 @@ def create_2d_detector_container(
     # YOLOX node
     yolox_package_dir = Path(get_package_share_directory("autoware_tensorrt_yolox"))
     yolox_param_path = Path(yolox_package_dir, "config", yolox_param_file).as_posix()
+    
+    # cspell:ignore semseg
     roi_to_semantic_segmentation_remap_path = Path(yolox_package_dir, "config", "roi_to_semseg_label_remap.csv").as_posix()
     yolox_params = {
         "model_path": yolox_model_path,

--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/camera_2d_detector.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/camera_2d_detector.py
@@ -56,10 +56,12 @@ def create_2d_detector_container(
     # YOLOX node
     yolox_package_dir = Path(get_package_share_directory("autoware_tensorrt_yolox"))
     yolox_param_path = Path(yolox_package_dir, "config", yolox_param_file).as_posix()
+    roi_to_semantic_segmentation_remap_path = Path(yolox_package_dir, "config", "roi_to_semseg_label_remap.csv").as_posix()
     yolox_params = {
         "model_path": yolox_model_path,
         "label_path": yolox_label_path,
         "color_map_path": yolox_color_map_path,
+        "roi_to_semantic_segmentation_remap_path": roi_to_semantic_segmentation_remap_path,
     }
     yolox_node = ComposableNode(
         package="autoware_tensorrt_yolox",


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Description
- https://evaluation.ci.tier4.jp/evaluation/reports/9ae2b628-208f-590c-a16c-2f070822ebc5/tests/e5a5f51a-def9-54bb-8cf7-e2b91feb6c01/624e10a5-a7b8-5b6f-a351-7f6d09d4f7da/581151c2-621a-5bb5-aa31-623f96f5ac55?project_id=x2_dev
```
[simulation-2] [ERROR] [launch_ros.actions.load_composable_nodes]: Failed to load node 'tensorrt_yolox_node0' of type 'autoware::tensorrt_yolox::TrtYoloXNode' in container '/perception/object_recognition/detection/camera_2d_detector_container0': Component constructor threw an exception: roi_to_semantic_segmentation_remap_path must be specified when `is_roi_overlap_segmentation` is true.
[simulation-2] [component_container-94] [INFO] [1782276784.473937014] [perception.object_recognition.detection.camera_2d_detector_container1]: Load Library: /home/autoware/pilot-auto/install
```

## How to review this PR

- Confirm the above error was fix on evaluator: https://evaluation.ci.tier4.jp/evaluation/reports/bf1a2253-46c9-5f92-92e9-e2bdb24b058e?project_id=x2_dev
- (the fail result seems because of different reason :thinking: )

## Others
