### PR TITLE
fix: disable EPDMS for optimized trajectory analysis

### DIFF
--- a/dependency/jazzy.repos
+++ b/dependency/jazzy.repos
@@ -22,7 +22,7 @@ repositories:
   autoware/autoware_lanelet2_extension:
     type: git
     url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-    version: 0.12.0
+    version: 1.0.0
   autoware/tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git

--- a/driving_log_replayer_v2/launch/post_process.launch.py
+++ b/driving_log_replayer_v2/launch/post_process.launch.py
@@ -258,6 +258,7 @@ def time_step_based_trajectory(conf: dict[str, str]) -> ProcessInfo:
         f"vehicle_model:={conf['vehicle_model']}",
         "trajectory_topic:=/planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/output/trajectory",
         "open_loop_metric_variant:=raw",
+        "debug_topics_enabled:=true",
         f"gt_source_mode:={conf['gt_source_mode']}",
         f"gt_trajectory_topic:={conf['gt_trajectory_topic']}",
         f"gt_sync_tolerance_ms:={conf['gt_sync_tolerance_ms']}",

--- a/driving_log_replayer_v2/launch/post_process.launch.py
+++ b/driving_log_replayer_v2/launch/post_process.launch.py
@@ -243,6 +243,7 @@ def time_step_based_trajectory(conf: dict[str, str]) -> ProcessInfo:
         f"vehicle_model:={conf['vehicle_model']}",
         "trajectory_topic:=/planning/trajectory",
         "open_loop_metric_variant:=optimized",
+        "enable_epdms_calculation:=false",
         f"gt_source_mode:={conf['gt_source_mode']}",
         f"gt_trajectory_topic:={conf['gt_trajectory_topic']}",
         f"gt_sync_tolerance_ms:={conf['gt_sync_tolerance_ms']}",

--- a/repository.cspell.json
+++ b/repository.cspell.json
@@ -8,6 +8,7 @@
     "conlist",
     "devkit",
     "dtick",
+    "epdms",
     "fastjsonschema",
     "fillna",
     "fintekcan",


### PR DESCRIPTION
## Summary
- Disable EPDMS calculation for the optimized trajectory analyzer run.
- Enable EPDMS debug topics for the raw diffusion trajectory analyzer run.
- Keep raw EPDMS calculation enabled by default.

## Background
This pairs with autoware_tools support for enable_epdms_calculation and debug_topics_enabled. DLR runs the analyzer twice: optimized should produce base open-loop metrics only, while raw should produce base metrics, EPDMS, and EPDMS debug topics.

## To reviewers
Please refer to this PR:https://github.com/tier4/autoware_tools/pull/62

## Validation
- Evaluator run: https://evaluation.ci.tier4.jp/evaluation/reports/c2024e7c-c59b-59c7-8aaa-85b4e82ab308?project_id=x2_dev

All EPDMS metrics and debug topics are produced as intended.