### PR TITLE
fix: use time_offset correctly even if play_rate is not 1.0

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/rosbag.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/rosbag.py
@@ -150,6 +150,8 @@ def get_rosbag_timestamp_offset(play_cmd: list[str], context: LaunchContext) -> 
         play_cmd.extend(["--start-offset", str(start)])
     duration = time_offset.get("duration", None)
     if duration is not None:
+        play_rate = float(conf["play_rate"])
+        duration = duration / play_rate
         play_cmd = ["timeout", "--preserve-status", str(duration), *play_cmd]
     return play_cmd
 


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Description

This PR modified the duration correctly because it was broken when set play_rate != 1.0.

## How to review this PR

## Others
