### PR TITLE
feat(perception_reproducer): wire auto-tackle-stuck CLI and remove post-engage pose push

### DIFF
--- a/docs/use_case/perception_reproducer.en.md
+++ b/docs/use_case/perception_reproducer.en.md
@@ -169,6 +169,11 @@ Configuration options:
 - `reproduce_cool_down`: Cool down time for republishing (default: 80.0)
 - `tracked_object`: Publish tracked object
 - `search_radius`: Search radius for searching rosbag's ego odom messages (default: 1.5)
+- `auto_tackle_stuck`: Expand search radius then perturb ego when stuck in repeat (default: true in DLR)
+- `stuck_duration`: The reproducer will try to tackle stuck by expanding search radius then perturb ego when the duration is longer than this value (default: 5.0)
+- `expand_radius_scale`: One-shot search radius scale when stuck. For example, if `search_radius` is 1.5 m and `expand_radius_scale` is 3.0, the expand radius will be 1.5 m \* 3.0 = 4.5 m when stuck (default: 3.0)
+- `perturb_distance`: The reproducer will perturb ego by this distance when ego is still stuck after the expand radius is applied (default: 0.5)
+- `output_metrics`: Dump metrics JSON on shutdown under `$ROS_LOG_DIR/autoware_metrics/` (default: true in DLR)
 
 ### Route Method
 

--- a/docs/use_case/perception_reproducer.ja.md
+++ b/docs/use_case/perception_reproducer.ja.md
@@ -169,6 +169,11 @@ Published topics:
 - `reproduce_cool_down`: 再パブリッシュのクールダウン時間（デフォルト: 80.0）
 - `tracked_object`: 追跡オブジェクトをパブリッシュする
 - `search_radius`: rosbagの自車オドメトリメッセージを検索する検索半径（デフォルト: 1.5）
+- `auto_tackle_stuck`: `repeat` でスタックしたとき、検索半径を拡大してから ego を perturb する（DLR ではデフォルト true）
+- `stuck_duration`: この秒数より長くスタックした場合、検索半径の拡大に続いて ego を perturb して stuck を解消しようとする（デフォルト: 5.0）
+- `expand_radius_scale`: stuck 時に一度だけ適用する検索半径のスケール。例: `search_radius` が 1.5 m、`expand_radius_scale` が 3.0 のとき、expand 半径は 1.5 m \* 3.0 = 4.5 m（デフォルト: 3.0）
+- `perturb_distance`: expand 後も stuck している場合に、この距離だけ ego を perturb する（デフォルト: 0.5）
+- `output_metrics`: 終了時に `$ROS_LOG_DIR/autoware_metrics/` へ metrics JSON を出力する（DLR ではデフォルト true）
 
 ### ルート設定方法
 

--- a/driving_log_replayer_v2/config/record/perception_reproducer.yaml
+++ b/driving_log_replayer_v2/config/record/perception_reproducer.yaml
@@ -20,4 +20,5 @@ record:
   - "^/api/operation_mode/state$"
   - "^/awapi/.*/get/.*$"
   - "^/perception_reproducer/rosbag_ego_odom$"
+  - "^/perception_reproducer/metrics$"
   - "^/sensing/gnss/septentrio/nav_sat_fix"

--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/argument.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/argument.py
@@ -265,10 +265,6 @@ def update_conf_with_dataset_info(
 
     if conf["use_case"] in ["perception_reproducer"]:
         conf["timeout_s"] = yaml_obj["Evaluation"]["Conditions"]["timeout_s"]
-        reproducer_config = yaml_obj["Evaluation"].get("perception_reproducer_config", {})
-        conf["move_ego_forward_after_engage_m"] = str(
-            reproducer_config.get("move_ego_forward_after_engage_m", 0.1)
-        )
 
     # higher priority to argument than scenario
     if conf["publish_profile"] == "" and yaml_obj.get("publish_profile"):

--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/perception_reproducer.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/perception_reproducer.py
@@ -12,14 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
-
 from launch import LaunchContext
 from launch.actions import DeclareLaunchArgument
-from launch.actions import LogInfo
 from launch.actions import OpaqueFunction
-from launch.actions import RegisterEventHandler
-from launch.event_handlers import OnProcessExit
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
@@ -30,8 +25,6 @@ from driving_log_replayer_v2.launch.use_case import launch_autoware
 from driving_log_replayer_v2.launch.use_case import launch_evaluator_node
 from driving_log_replayer_v2.launch.use_case import launch_goal_pose_node
 from driving_log_replayer_v2.launch.use_case import launch_initial_pose_node
-from driving_log_replayer_v2.pose import offset_pose_dict_forward
-from driving_log_replayer_v2.pose import pose_str_to_dict
 
 AUTOWARE_DISABLE = {}
 
@@ -46,69 +39,22 @@ NODE_PARAMS: dict[str, LaunchConfiguration] = {}
 USE_CASE_ARGS: list[DeclareLaunchArgument] = []
 
 
-def _get_post_engage_direct_initial_pose(conf: dict) -> str | None:
-    move_ego_forward_after_engage_m = float(conf["move_ego_forward_after_engage_m"])
-    if move_ego_forward_after_engage_m == 0.0:
-        return None
-    base_pose = conf["direct_initial_pose"]
-    if base_pose == "{}":
-        base_pose = conf["initial_pose"]
-    if base_pose == "{}":
-        return None
-    # Perturb ego after engage so the planner stops publishing a stopping trajectory.
-    shifted_pose_dict = offset_pose_dict_forward(
-        pose_str_to_dict(base_pose),
-        move_ego_forward_after_engage_m,
-    )
-    return json.dumps(shifted_pose_dict)
-
-
-def launch_engage_sequence(context: LaunchContext) -> list:
+def launch_engage_node(context: LaunchContext) -> list:
     conf = context.launch_configurations
 
-    engage_node = Node(
-        package="driving_log_replayer_v2",
-        namespace="/driving_log_replayer_v2",
-        executable="engage_node.py",
-        output="screen",
-        name="engage_node",
-        parameters=[
-            {
-                "use_sim_time": False,
-                "timeout_s": float(conf["timeout_s"]),
-            }
-        ],
-    )
-
-    def launch_post_engage_initial_pose_node(_: LaunchContext) -> list:
-        post_engage_direct_initial_pose = _get_post_engage_direct_initial_pose(conf)
-        if post_engage_direct_initial_pose is None:
-            return [LogInfo(msg="post_engage_initial_pose_node is not activated")]
-        return [
-            LogInfo(msg="engage_node exited. launching post_engage_initial_pose_node"),
-            Node(
-                package="driving_log_replayer_v2",
-                namespace="/driving_log_replayer_v2",
-                executable="initial_pose_node.py",
-                output="screen",
-                name="post_engage_initial_pose_node",
-                parameters=[
-                    {
-                        "use_sim_time": False,
-                        "initial_pose": "{}",
-                        "direct_initial_pose": post_engage_direct_initial_pose,
-                    }
-                ],
-            ),
-        ]
-
     return [
-        engage_node,
-        RegisterEventHandler(
-            OnProcessExit(
-                target_action=engage_node,
-                on_exit=[OpaqueFunction(function=launch_post_engage_initial_pose_node)],
-            )
+        Node(
+            package="driving_log_replayer_v2",
+            namespace="/driving_log_replayer_v2",
+            executable="engage_node.py",
+            output="screen",
+            name="engage_node",
+            parameters=[
+                {
+                    "use_sim_time": False,
+                    "timeout_s": float(conf["timeout_s"]),
+                }
+            ],
         ),
     ]
 
@@ -122,5 +68,5 @@ def launch_perception_reproducer_use_case() -> list:
         OpaqueFunction(function=launch_evaluator_node),
         OpaqueFunction(function=launch_initial_pose_node),
         OpaqueFunction(function=launch_goal_pose_node),
-        OpaqueFunction(function=launch_engage_sequence),
+        OpaqueFunction(function=launch_engage_node),
     ]

--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/rosbag.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/rosbag.py
@@ -222,6 +222,29 @@ def launch_bag_recorder(context: LaunchContext) -> list:
     return [ExecuteProcess(cmd=record_cmd)]
 
 
+def _append_perception_reproducer_options(cmd: list[str], reproducer_config: dict) -> None:
+    bool_flags = (
+        ("noise", False, "--noise"),
+        ("tracked_object", False, "--tracked-object"),
+        ("replay_route", False, "--replay-route"),
+        ("auto_tackle_stuck", True, "--auto-tackle-stuck"),
+        ("output_metrics", True, "--output-metrics"),
+    )
+    value_flags = (
+        ("search_radius", "--search-radius"),
+        ("reproduce_cool_down", "--reproduce-cool-down"),
+        ("stuck_duration", "--stuck-duration"),
+        ("expand_radius_scale", "--expand-radius-scale"),
+        ("perturb_distance", "--perturb-distance"),
+    )
+    for key, default, flag in bool_flags:
+        if reproducer_config.get(key, default):
+            cmd.append(flag)
+    for key, flag in value_flags:
+        if reproducer_config.get(key) is not None:
+            cmd.extend([flag, str(reproducer_config[key])])
+
+
 def launch_perception_reproducer(context: LaunchContext) -> list:
     """Launch perception_reproducer node from planning_debug_tools."""
     conf = context.launch_configurations
@@ -246,26 +269,6 @@ def launch_perception_reproducer(context: LaunchContext) -> list:
     ).as_posix()
 
     cmd = [executable, "-b", conf["input_bag"], "-f", rosbag_format]
-
-    if reproducer_config.get("noise", False):
-        cmd.append("--noise")
-    if reproducer_config.get("tracked_object", False):
-        cmd.append("--tracked-object")
-    if reproducer_config.get("search_radius") is not None:
-        cmd.extend(["--search-radius", str(reproducer_config["search_radius"])])
-    if reproducer_config.get("reproduce_cool_down") is not None:
-        cmd.extend(["--reproduce-cool-down", str(reproducer_config["reproduce_cool_down"])])
-    if reproducer_config.get("replay_route", False):
-        cmd.append("--replay-route")
-    if reproducer_config.get("auto_tackle_stuck", True):
-        cmd.append("--auto-tackle-stuck")
-    if reproducer_config.get("stuck_duration") is not None:
-        cmd.extend(["--stuck-duration", str(reproducer_config["stuck_duration"])])
-    if reproducer_config.get("expand_radius_scale") is not None:
-        cmd.extend(["--expand-radius-scale", str(reproducer_config["expand_radius_scale"])])
-    if reproducer_config.get("perturb_distance") is not None:
-        cmd.extend(["--perturb-distance", str(reproducer_config["perturb_distance"])])
-    if reproducer_config.get("output_metrics", True):
-        cmd.append("--output-metrics")
+    _append_perception_reproducer_options(cmd, reproducer_config)
 
     return [ExecuteProcess(cmd=cmd, output="screen", on_exit=ShutdownOnce())]

--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/rosbag.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/rosbag.py
@@ -237,12 +237,20 @@ def _append_perception_reproducer_options(cmd: list[str], reproducer_config: dic
         ("expand_radius_scale", "--expand-radius-scale"),
         ("perturb_distance", "--perturb-distance"),
     )
+    value_defaults = {
+        "search_radius": 1.5,
+        "reproduce_cool_down": 999.0,
+        "stuck_duration": 5.0,
+        "expand_radius_scale": 3.0,
+        "perturb_distance": 0.5,
+    }
     for key, default, flag in bool_flags:
         if reproducer_config.get(key, default):
             cmd.append(flag)
     for key, flag in value_flags:
-        if reproducer_config.get(key) is not None:
-            cmd.extend([flag, str(reproducer_config[key])])
+        value = reproducer_config[key] if key in reproducer_config else value_defaults.get(key)
+        if value is not None:
+            cmd.extend([flag, str(value)])
 
 
 def launch_perception_reproducer(context: LaunchContext) -> list:

--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/rosbag.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/rosbag.py
@@ -257,5 +257,15 @@ def launch_perception_reproducer(context: LaunchContext) -> list:
         cmd.extend(["--reproduce-cool-down", str(reproducer_config["reproduce_cool_down"])])
     if reproducer_config.get("replay_route", False):
         cmd.append("--replay-route")
+    if reproducer_config.get("auto_tackle_stuck", True):
+        cmd.append("--auto-tackle-stuck")
+    if reproducer_config.get("stuck_duration") is not None:
+        cmd.extend(["--stuck-duration", str(reproducer_config["stuck_duration"])])
+    if reproducer_config.get("expand_radius_scale") is not None:
+        cmd.extend(["--expand-radius-scale", str(reproducer_config["expand_radius_scale"])])
+    if reproducer_config.get("perturb_distance") is not None:
+        cmd.extend(["--perturb-distance", str(reproducer_config["perturb_distance"])])
+    if reproducer_config.get("output_metrics", True):
+        cmd.append("--output-metrics")
 
     return [ExecuteProcess(cmd=cmd, output="screen", on_exit=ShutdownOnce())]

--- a/driving_log_replayer_v2/driving_log_replayer_v2/perception_reproducer.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/perception_reproducer.py
@@ -78,6 +78,11 @@ class PerceptionReproducerConfig(BaseModel):
     search_radius: float = Field(1.5, ge=0.0)
     replay_route: bool = False
     move_ego_forward_after_engage_m: float = 0.1
+    auto_tackle_stuck: bool = True
+    stuck_duration: float = Field(5.0, ge=0.0)
+    expand_radius_scale: float = Field(3.0, gt=0.0)
+    perturb_distance: float = Field(0.5, ge=0.0)
+    output_metrics: bool = True
 
 
 class _DeprecatedTimeField:

--- a/driving_log_replayer_v2/driving_log_replayer_v2/perception_reproducer.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/perception_reproducer.py
@@ -77,7 +77,6 @@ class PerceptionReproducerConfig(BaseModel):
     tracked_object: bool = False
     search_radius: float = Field(1.5, ge=0.0)
     replay_route: bool = False
-    move_ego_forward_after_engage_m: float = 0.1
     auto_tackle_stuck: bool = True
     stuck_duration: float = Field(5.0, ge=0.0)
     expand_radius_scale: float = Field(3.0, gt=0.0)

--- a/sample/perception_reproducer/scenario.yaml
+++ b/sample/perception_reproducer/scenario.yaml
@@ -40,7 +40,7 @@ Evaluation:
     auto_tackle_stuck: true # --auto-tackle-stuck: expand search radius then perturb ego when stuck in repeat
     stuck_duration: 5.0 # --stuck-duration [s]: the reproducer will try to tackle stuck by expanding search radius then perturb ego when the duration is longer than this value.
     expand_radius_scale: 3.0 # --expand-radius-scale: one-shot search radius scale when stuck, for example, if the search radius is 1.5m, the expand radius scale is 3.0, the expand radius will be 1.5m * 3.0 = 4.5m when stuck.
-    perturb_distance: 0.5 # --perturb-distance [m]: the reproducer will perturb ego by this distance when ego still stucked after the expand radius is applied.
+    perturb_distance: 0.5 # --perturb-distance [m]: the reproducer will perturb ego by this distance when ego still stuck after the expand radius is applied.
     output_metrics: true # --output-metrics: dump metrics JSON on shutdown
 
   Conditions:

--- a/sample/perception_reproducer/scenario.yaml
+++ b/sample/perception_reproducer/scenario.yaml
@@ -38,6 +38,11 @@ Evaluation:
     tracked_object: false # -t, --tracked-object: publish tracked object
     search_radius: 1.5 # -r, --search-radius: search radius for searching rosbag's ego odom messages (default: 1.5)
     move_ego_forward_after_engage_m: 0.1 # [m] after engage, perturb ego along its forward axis to let the planner start generating a moving trajectory; set 0 to disable, negative values move in the opposite direction
+    auto_tackle_stuck: true # --auto-tackle-stuck
+    stuck_duration: 5.0 # --stuck-duration [s]
+    expand_radius_scale: 3.0 # --expand-radius-scale
+    perturb_distance: 0.5 # --perturb-distance [m]
+    output_metrics: true # --output-metrics
 
   Conditions:
     timeout_s: 80.0 # [s] scenario timeout duration, used for both engage_node and perception_reproducer_evaluator_node

--- a/sample/perception_reproducer/scenario.yaml
+++ b/sample/perception_reproducer/scenario.yaml
@@ -37,12 +37,11 @@ Evaluation:
     reproduce_cool_down: 999.0 # -c, --reproduce-cool-down: cool down time for republishing (default: 80.0)
     tracked_object: false # -t, --tracked-object: publish tracked object
     search_radius: 1.5 # -r, --search-radius: search radius for searching rosbag's ego odom messages (default: 1.5)
-    move_ego_forward_after_engage_m: 0.1 # [m] after engage, perturb ego along its forward axis to let the planner start generating a moving trajectory; set 0 to disable, negative values move in the opposite direction
-    auto_tackle_stuck: true # --auto-tackle-stuck
-    stuck_duration: 5.0 # --stuck-duration [s]
-    expand_radius_scale: 3.0 # --expand-radius-scale
-    perturb_distance: 0.5 # --perturb-distance [m]
-    output_metrics: true # --output-metrics
+    auto_tackle_stuck: true # --auto-tackle-stuck: expand search radius then perturb ego when stuck in repeat
+    stuck_duration: 5.0 # --stuck-duration [s]: the reproducer will try to tackle stuck by expanding search radius then perturb ego when the duration is longer than this value.
+    expand_radius_scale: 3.0 # --expand-radius-scale: one-shot search radius scale when stuck, for example, if the search radius is 1.5m, the expand radius scale is 3.0, the expand radius will be 1.5m * 3.0 = 4.5m when stuck.
+    perturb_distance: 0.5 # --perturb-distance [m]: the reproducer will perturb ego by this distance when ego still stucked after the expand radius is applied.
+    output_metrics: true # --output-metrics: dump metrics JSON on shutdown
 
   Conditions:
     timeout_s: 80.0 # [s] scenario timeout duration, used for both engage_node and perception_reproducer_evaluator_node

--- a/sample/perception_reproducer/scenario_sample.yaml
+++ b/sample/perception_reproducer/scenario_sample.yaml
@@ -36,7 +36,11 @@ Evaluation:
     reproduce_cool_down: 999.0
     search_radius: 1.5
     tracked_object: false
-    move_ego_forward_after_engage_m: 0.1
+    auto_tackle_stuck: true
+    stuck_duration: 5.0
+    expand_radius_scale: 3.0
+    perturb_distance: 0.5
+    output_metrics: true
   Conditions:
     terminated_after_fail_s: 10
     timeout_s: 119.797183508


### PR DESCRIPTION
## Types of PR

- [x] New Features
- [x] Upgrade of existing features
- [ ] Bugfix

## Description

Wire DLR `perception_reproducer` scenario config to the new `planning_debug_tools` auto-tackle-stuck CLI ([tier4/autoware_tools#65](https://github.com/tier4/autoware_tools/pull/65)), and remove the DLR-side post-engage pose push that repeatedly relaunched `initial_pose_node`.

### Changes

- Map scenario `perception_reproducer_config` to CLI flags:
  - `auto_tackle_stuck` → `--auto-tackle-stuck` (default `true` in DLR)
  - `stuck_duration` → `--stuck-duration` (default `5.0`)
  - `expand_radius_scale` → `--expand-radius-scale` (default `3.0`)
  - `perturb_distance` → `--perturb-distance` (default `0.5`)
  - `output_metrics` → `--output-metrics` (default `true` in DLR)
- Remove `move_ego_forward_after_engage_m` and `post_engage_initial_pose_node` (engage-after push). Keep one-shot `initial_pose_node` + `engage_node`.
- Record `/perception_reproducer/metrics` in the perception_reproducer record profile.
- Update sample scenarios and EN/JA docs.

### Dependency

Requires `planning_debug_tools` with auto-tackle-stuck support (autoware_tools#65).

## How to review this PR

1. Check `launch/rosbag.py` maps the new config fields to the expected CLI options.
2. Confirm `launch/perception_reproducer.py` no longer starts `post_engage_initial_pose_node`, but still launches `engage_node`.
3. Confirm sample/docs no longer mention `move_ego_forward_after_engage_m`.
4. Optional: run a perception_reproducer scenario that previously stuck after engage / red light, with `auto_tackle_stuck: true`, and verify expand → perturb recovery and metrics output.

## Others

- Breaking for old scenarios that relied on `move_ego_forward_after_engage_m`; migrate to the new `auto_tackle_*` / `perturb_distance` options.
- DLR enables `auto_tackle_stuck` / `output_metrics` by default (standalone binary defaults are off).


Made with [Cursor](https://cursor.com)