### PR TITLE
fix: introduce use_sim_time as global parameter

### DIFF
--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/use_case.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/use_case.py
@@ -26,6 +26,7 @@ from launch.actions import OpaqueFunction
 from launch.actions import UnsetEnvironmentVariable
 from launch.launch_description_sources import AnyLaunchDescriptionSource
 from launch_ros.actions import Node
+from launch_ros.actions import SetParameter
 from rosidl_runtime_py import message_to_ordereddict
 
 from driving_log_replayer_v2.launch.argument import add_use_case_arguments
@@ -177,12 +178,18 @@ def launch_topic_state_monitor(context: LaunchContext) -> list:
         "topic_state_monitor.yaml",
     )
     return [
-        IncludeLaunchDescription(
-            AnyLaunchDescriptionSource(component_state_monitor_launch_file.as_posix()),
-            launch_arguments={
-                "file": topic_monitor_config_path.as_posix(),
-                "mode": "logging_simulation",
-            }.items(),
+        GroupAction(
+            [
+                SetParameter(name="use_sim_time", value=True),
+                IncludeLaunchDescription(
+                    AnyLaunchDescriptionSource(component_state_monitor_launch_file.as_posix()),
+                    launch_arguments={
+                        "file": topic_monitor_config_path.as_posix(),
+                        "mode": "logging_simulation",
+                    }.items(),
+                ),
+            ],
+            scoped=True,
         ),
     ]
 

--- a/driving_log_replayer_v2/driving_log_replayer_v2/launch/use_case.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/launch/use_case.py
@@ -133,6 +133,7 @@ def launch_evaluator_node(context: LaunchContext) -> list:
         output_dummy_result_jsonl(conf["result_jsonl_path"])
         return [LogInfo(msg="evaluator_node is not launched due to record only mode")]
     params = {
+        # if use_case is perception_reproducer, use_sim_time is overridden to False
         "use_sim_time": conf["use_case"] != "perception_reproducer",
         "scenario_path": conf["scenario_path"],
         "t4_dataset_path": conf["t4_dataset_path"],
@@ -178,18 +179,12 @@ def launch_topic_state_monitor(context: LaunchContext) -> list:
         "topic_state_monitor.yaml",
     )
     return [
-        GroupAction(
-            [
-                SetParameter(name="use_sim_time", value=True),
-                IncludeLaunchDescription(
-                    AnyLaunchDescriptionSource(component_state_monitor_launch_file.as_posix()),
-                    launch_arguments={
-                        "file": topic_monitor_config_path.as_posix(),
-                        "mode": "logging_simulation",
-                    }.items(),
-                ),
-            ],
-            scoped=True,
+        IncludeLaunchDescription(
+            AnyLaunchDescriptionSource(component_state_monitor_launch_file.as_posix()),
+            launch_arguments={
+                "file": topic_monitor_config_path.as_posix(),
+                "mode": "logging_simulation",
+            }.items(),
         ),
     ]
 
@@ -203,6 +198,7 @@ def launch_initial_pose_node(context: LaunchContext) -> list:
         return [LogInfo(msg="initial_pose_node is not activated")]
 
     params = {
+        # if use_case is perception_reproducer, use_sim_time is overridden to False
         "use_sim_time": conf["use_case"] != "perception_reproducer",
         "initial_pose": initial_pose,
         "direct_initial_pose": direct_initial_pose,
@@ -250,6 +246,7 @@ def launch_goal_pose_node(context: LaunchContext) -> list:
         ]
 
     params = {
+        # if use_case is perception_reproducer, use_sim_time is overridden to False
         "use_sim_time": conf["use_case"] != "perception_reproducer",
         "goal_pose": goal_pose,
     }
@@ -268,6 +265,8 @@ def launch_goal_pose_node(context: LaunchContext) -> list:
 
 def launch_use_case() -> list:
     return [
+        # Once for all DLR-side nodes. Survives Autoware's scoped GroupAction (forwarding=True).
+        SetParameter(name="use_sim_time", value=True),
         OpaqueFunction(function=add_use_case_arguments),  # after ensure_arg_compatibility
         OpaqueFunction(function=launch_autoware),
         OpaqueFunction(function=launch_optional_nodes),

--- a/driving_log_replayer_v2/launch/simulation.launch.py
+++ b/driving_log_replayer_v2/launch/simulation.launch.py
@@ -33,7 +33,9 @@ def select_launch(context: LaunchContext) -> list:
     if conf["use_case"] == "ndt_convergence":
         return launch_ndt_convergence(context)
     if conf["use_case"] == "perception_reproducer":
+        # closed loop
         return launch_perception_reproducer_use_case()
+    # open loop
     return launch_use_case()
 
 


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Description

This PR introduces the global parameter `use_sim_time`. 

In DLR, each node is set to use_sim_time:=true, so maintenance cost is bit high. And autoware_launch has use_sim_time:=true and DLR used it implicitly. (But this implicit define was resolved in https://github.com/tier4/driving_log_replayer_v2/pull/381. So topic_state_monitor was running on use_sim_time:=false when that is resolved.)


## How to review this PR

https://tier4.atlassian.net/browse/T4DEV-55782

## Others
