### PR TITLE
feat(perception_fp): report FpObjects in base_link and the ego pose

### DIFF
--- a/docs/use_case/perception_fp.en.md
+++ b/docs/use_case/perception_fp.en.md
@@ -144,6 +144,8 @@ Format of each frame:
           "Frame": "Success or Fail"
         },
         "Info": {
+          "FrameId": "map",
+          "EgoPose": { "frame_id": "map", "position": { "x": 0.0, "y": 0.0, "z": 0.0 }, "yaw": 0.0 },
           "FpObjects": [
             {
               "label": "Label of the object detected inside the non-detection area",
@@ -151,7 +153,9 @@ Format of each frame:
               "position": { "x": 0.0, "y": 0.0, "z": 0.0 },
               "velocity": { "x": 0.0, "y": 0.0, "z": 0.0 },
               "orientation": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0 },
-              "shape": { "x": 0.0, "y": 0.0, "z": 0.0 }
+              "shape": { "x": 0.0, "y": 0.0, "z": 0.0 },
+              "position_base_link": { "x": 0.0, "y": 0.0, "z": 0.0 },
+              "yaw_base_link": 0.0
             }
           ]
         }
@@ -176,6 +180,7 @@ Format of each frame:
 `Info` describes what was found inside the non-detection area and is empty on passing frames.
 For bbox topics it holds `FpObjects` (one entry per object whose bounding box entered the area);
 for pointcloud topics it holds `FpPoints` (the coordinate of points inside the area(list[list[float]])).
+`FrameId` is the frame the objects were published in (normally `map`), `EgoPose` places the ego vehicle (base_link origin) in `map` at that frame, and each object additionally carries `position_base_link` / `yaw_base_link`: the same object seen from the ego vehicle, so a viewer can draw it around the ego together with the non-detection area without replaying the bag.
 
 Warning Data Format:
 

--- a/docs/use_case/perception_fp.ja.md
+++ b/docs/use_case/perception_fp.ja.md
@@ -143,6 +143,8 @@ perception では、シナリオに指定した条件で perception_eval が評�
           "Frame": "Success or Fail"
         },
         "Info": {
+          "FrameId": "map",
+          "EgoPose": { "frame_id": "map", "position": { "x": 0.0, "y": 0.0, "z": 0.0 }, "yaw": 0.0 },
           "FpObjects": [
             {
               "label": "非検知エリア内で検出されたオブジェクトのラベル",
@@ -150,7 +152,9 @@ perception では、シナリオに指定した条件で perception_eval が評�
               "position": { "x": 0.0, "y": 0.0, "z": 0.0 },
               "velocity": { "x": 0.0, "y": 0.0, "z": 0.0 },
               "orientation": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0 },
-              "shape": { "x": 0.0, "y": 0.0, "z": 0.0 }
+              "shape": { "x": 0.0, "y": 0.0, "z": 0.0 },
+              "position_base_link": { "x": 0.0, "y": 0.0, "z": 0.0 },
+              "yaw_base_link": 0.0
             }
           ]
         }
@@ -175,6 +179,7 @@ perception では、シナリオに指定した条件で perception_eval が評�
 `Info` には非検知エリア内で検出された内容が入る。合格フレームでは空となる。
 bbox の topic では `FpObjects`（バウンディングボックスがエリアに入ったオブジェクトごとに 1 エントリ）、
 pointcloud の topic では `FpPoints`（エリア内の点群の座標(list[list[float]])）が入る。
+`FrameId` はオブジェクトが publish されていた座標系（通常 `map`）、`EgoPose` はそのフレームでの自車（base_link 原点）の `map` 上の位置と yaw、各オブジェクトの `position_base_link` / `yaw_base_link` は同じオブジェクトを自車から見た座標である。これにより rosbag を再生しなくても非検知エリアと一緒に自車周りに描画できる。
 
 警告のフォーマット
 

--- a/driving_log_replayer_v2/driving_log_replayer_v2/perception_fp/models.py
+++ b/driving_log_replayer_v2/driving_log_replayer_v2/perception_fp/models.py
@@ -263,6 +263,11 @@ class PerceptionFP(EvaluationItem):
             return {"Info": "Not in evaluation topic type"}
 
         self.total += 1
+        # kept for summarize_fp_objects: FpObjects are published in `frame_id` (usually map),
+        # the dashboards draw them around the ego vehicle, so the base_link view is derived here
+        self._data_frame_id = frame_id
+        self._map_to_base_link = map_to_base_link
+        self._base_link_to_map = base_link_to_map
 
         is_in_non_detection_area = self.is_in_non_detection_area(
             frame_id, data, map_to_base_link, base_link_to_map, is_valid_timestamp=True
@@ -291,13 +296,68 @@ class PerceptionFP(EvaluationItem):
             return None
         return {"x": values[0], "y": values[1], "z": values[2]}
 
+    @staticmethod
+    def _transform_point(matrix: np.ndarray, point: tuple[float, float, float]) -> dict:
+        p = matrix @ np.array([point[0], point[1], point[2], 1.0])
+        return {"x": float(p[0]), "y": float(p[1]), "z": float(p[2])}
+
+    @staticmethod
+    def _matrix_yaw(matrix: np.ndarray) -> float:
+        """Yaw (rad) of the rotation part of a 4x4 homogeneous transform."""
+        return float(np.arctan2(matrix[1, 0], matrix[0, 0]))
+
+    @staticmethod
+    def _quaternion_yaw(orientation: Any) -> float | None:
+        if orientation is None:
+            return None
+        x, y, z, w = orientation.x, orientation.y, orientation.z, orientation.w
+        return float(np.arctan2(2.0 * (w * z + x * y), 1.0 - 2.0 * (y * y + z * z)))
+
+    @staticmethod
+    def _wrap_angle(angle: float) -> float:
+        return float((angle + np.pi) % (2.0 * np.pi) - np.pi)
+
+    def _to_base_link(self, obj: DynamicObject) -> tuple[dict | None, float | None]:
+        """
+        Position and yaw of an object in base_link, whatever frame it was published in.
+
+        Uses the same map<->base_link transform the polygon check used for this frame, so
+        the object lands exactly where it was judged against the (base_link) area.
+        """
+        data_frame_id = getattr(self, "_data_frame_id", None)
+        yaw = self._quaternion_yaw(obj.state.orientation)
+        if obj.state.position is None:
+            return None, None
+        if data_frame_id == "base_link":
+            return self._fill_xyz(obj.state.position), yaw
+        matrix = getattr(self, "_map_to_base_link", None)
+        if data_frame_id != "map" or matrix is None:
+            return None, None
+        position = self._transform_point(matrix, obj.state.position)
+        if yaw is None:
+            return position, None
+        return position, self._wrap_angle(yaw + self._matrix_yaw(matrix))
+
+    def _ego_pose(self) -> dict | None:
+        """Ego (base_link origin) in map at this frame: what a viewer needs to overlay both frames."""
+        matrix = getattr(self, "_base_link_to_map", None)
+        if matrix is None:
+            return None
+        return {
+            "frame_id": "map",
+            "position": self._transform_point(matrix, (0.0, 0.0, 0.0)),
+            "yaw": self._matrix_yaw(matrix),
+        }
+
     def summarize_fp_objects(self) -> dict:
         """
         Describe what was found inside the non-detection area, for result.jsonl.
 
         Empty on passing frames. Object entries mirror
         FrameDescriptionWriter.object_to_description, but are built locally so this
-        module stays importable without a ROS environment.
+        module stays importable without a ROS environment. `position`/`orientation` are
+        as published (see `FrameId`); `position_base_link`/`yaw_base_link` are the same
+        object seen from the ego vehicle, and `EgoPose` places base_link in map.
         """
         if isinstance(self._fp_objects, np.ndarray):
             if self._fp_objects.size == 0:
@@ -305,8 +365,10 @@ class PerceptionFP(EvaluationItem):
             return {"FpPoints": self._fp_objects.tolist()}
         if not self._fp_objects:
             return {}
-        return {
-            "FpObjects": [
+        fp_objects = []
+        for obj in self._fp_objects:
+            position_base_link, yaw_base_link = self._to_base_link(obj)
+            fp_objects.append(
                 {
                     "label": obj.semantic_label.name,
                     "uuid": obj.uuid,
@@ -321,9 +383,14 @@ class PerceptionFP(EvaluationItem):
                     if obj.state.orientation is not None
                     else None,
                     "shape": self._fill_xyz(obj.state.size),
+                    "position_base_link": position_base_link,
+                    "yaw_base_link": yaw_base_link,
                 }
-                for obj in self._fp_objects
-            ],
+            )
+        return {
+            "FrameId": getattr(self, "_data_frame_id", None),
+            "EgoPose": self._ego_pose(),
+            "FpObjects": fp_objects,
         }
 
     def is_in_non_detection_area(

--- a/driving_log_replayer_v2/test/unittest/test_perception_fp.py
+++ b/driving_log_replayer_v2/test/unittest/test_perception_fp.py
@@ -155,6 +155,8 @@ def test_in_non_detection_area(
                 "Frame": "Fail",
             },
             "Info": {
+                "FrameId": "map",
+                "EgoPose": {"frame_id": "map", "position": {"x": 0.0, "y": 0.0, "z": 0.0}, "yaw": 0.0},
                 "FpObjects": [
                     {
                         "label": "car",
@@ -163,8 +165,94 @@ def test_in_non_detection_area(
                         "velocity": {"x": 1.0, "y": 2.0, "z": 3.0},
                         "orientation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0},
                         "shape": {"x": 1.0, "y": 2.0, "z": 6.0},
+                        # identity transform: base_link == map here
+                        "position_base_link": {"x": 0.5, "y": 1.0, "z": 3.0},
+                        "yaw_base_link": 0.0,
                     },
                 ],
             },
         },
     }
+
+
+def test_fp_objects_are_also_reported_in_base_link(create_criteria: Criteria) -> None:
+    """Objects arrive in map; the dashboards draw around the ego, so base_link is derived.
+
+    Ego at map (100, 50) heading +90 deg. An object 5 m ahead of the ego (and inside the
+    map-frame area once the area is expressed around the ego) must come back as
+    base_link (5, 0) with yaw 0 relative to the ego.
+    """
+    theta = np.pi / 2
+    base_link_to_map = np.array(
+        [
+            [np.cos(theta), -np.sin(theta), 0.0, 100.0],
+            [np.sin(theta), np.cos(theta), 0.0, 50.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+    map_to_base_link = np.linalg.inv(base_link_to_map)
+    # area given in base_link: 0..10 m ahead, +-1.5 m -> the object 5 m ahead is inside
+    criteria = create_criteria.model_copy(
+        update={
+            "non_detection_area": NonDetectionArea(
+                frame_id="base_link",
+                polygon=[[10.0, 1.5, 0.0], [10.0, -1.5, 0.0], [0.0, -1.5, 0.0], [0.0, 1.5, 0.0]],
+            )
+        }
+    )
+    obj = DynamicObject(
+        unix_time=123,
+        frame_id=FrameID.MAP,
+        position=(100.0, 55.0, 0.0),  # 5 m ahead of an ego heading +y
+        orientation=Quaternion(axis=[0, 0, 1], angle=theta),  # same heading as the ego
+        shape=Shape(ShapeType.BOUNDING_BOX, (1.0, 1.0, 1.0)),
+        velocity=(0.0, 0.0, 0.0),
+        semantic_score=0.5,
+        semantic_label=Label(AutowareLabel.CAR, "car"),
+    )
+    perception_fp = PerceptionFP(name=criteria.criteria_name, condition=criteria)
+    result = perception_fp.set_frame(
+        timestamp=obj.unix_time * 1e3,
+        frame_id="map",
+        data=[obj],
+        map_to_base_link=map_to_base_link,
+        base_link_to_map=base_link_to_map,
+    )
+    info = result["PassFail"]["Info"]
+    assert result["PassFail"]["Result"]["Frame"] == "Fail"
+    assert info["FrameId"] == "map"
+    assert np.allclose(
+        [info["EgoPose"]["position"]["x"], info["EgoPose"]["position"]["y"]], [100.0, 50.0]
+    )
+    assert np.isclose(info["EgoPose"]["yaw"], theta)
+    fp = info["FpObjects"][0]
+    assert fp["position"] == {"x": 100.0, "y": 55.0, "z": 0.0}, "published position stays untouched"
+    assert np.allclose(
+        [fp["position_base_link"]["x"], fp["position_base_link"]["y"], fp["position_base_link"]["z"]],
+        [5.0, 0.0, 0.0],
+    )
+    assert np.isclose(fp["yaw_base_link"], 0.0)
+
+
+def test_passing_frame_keeps_info_empty(create_criteria: Criteria) -> None:
+    obj = DynamicObject(
+        unix_time=123,
+        frame_id=FrameID.MAP,
+        position=(50.0, 50.0, 0.0),  # far outside the area
+        orientation=Quaternion(),
+        shape=Shape(ShapeType.BOUNDING_BOX, (1.0, 1.0, 1.0)),
+        velocity=(0.0, 0.0, 0.0),
+        semantic_score=0.5,
+        semantic_label=Label(AutowareLabel.CAR, "car"),
+    )
+    perception_fp = PerceptionFP(name=create_criteria.criteria_name, condition=create_criteria)
+    result = perception_fp.set_frame(
+        timestamp=obj.unix_time * 1e3,
+        frame_id="map",
+        data=[obj],
+        map_to_base_link=np.eye(4),
+        base_link_to_map=np.eye(4),
+    )
+    assert result["PassFail"]["Result"]["Frame"] == "Success"
+    assert result["PassFail"]["Info"] == {}


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [x] Upgrade of existing features
- [ ] Bugfix

## Description

Follow-up to #398 (3.18.10), which records the objects found inside each non-detection area as `Info.FpObjects`. Those entries carry `position` / `orientation` exactly as published, i.e. in the topic's frame (`map` for the perception pipeline), and `result.jsonl` has no ego pose, so a viewer that draws the non-detection polygons in `base_link` cannot place the objects — the TIER IV dashboard currently draws them at the centroid of the violated area.

This PR adds, using the same map↔base_link transform the polygon check already computed for the frame:

- per object: `position_base_link` (`{x, y, z}`) and `yaw_base_link`
- per frame: `FrameId` (the data frame the objects were published in) and `EgoPose` (`base_link` origin and yaw in `map`)

Existing keys are untouched; `Info` stays `{}` on passing frames; objects already published in `base_link` pass through unchanged. numpy only, no new ROS imports.

## How to review this PR

- `driving_log_replayer_v2/perception_fp/models.py`: `set_frame` keeps the frame id and the two 4×4 transforms; `summarize_fp_objects` adds the base_link view via `_to_base_link` / `_ego_pose`.
- `test/unittest/test_perception_fp.py`: extended failing-frame assertion; new `test_fp_objects_are_also_reported_in_base_link` (ego at (100, 50) heading +90°, object 5 m ahead → base_link (5, 0), yaw 0) and `test_passing_frame_keeps_info_empty`.
- `docs/use_case/perception_fp.{en,ja}.md`: frame-format example.

## Tests performed

Unit tests run with a ROS Humble + pilot-auto workspace sourced: 9 passed (`test_scenario` needs the built share dir, as with #398).

## Effects on system behavior

Additive fields in `result.jsonl` for perception_fp failing frames only.

## Interface changes

None (new optional keys in the perception_fp `Info` payload).

## Others

Motivation: RDDR-1026 (dashboard visualisation of non-detection-area failures). Not needed for the 2026-09 evaluation round: 3.18.10 already provides the evidence; this only makes the placement exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)